### PR TITLE
Allow DP-LSTM to have null init

### DIFF
--- a/opacus/layers/dp_lstm.py
+++ b/opacus/layers/dp_lstm.py
@@ -102,7 +102,7 @@ class DPLSTM(nn.Module):
 
     def _rearrange_batch_dim(self, x):
         if self.batch_first:  # batch is by default in second dimension
-            return x.permute(1, 0, 2)
+            x = x.transpose(0, 1)
         return x
 
     def initialize_weights(self, weight_params):
@@ -113,9 +113,9 @@ class DPLSTM(nn.Module):
             self.bias_hh_l0,
         ] = weight_params
 
-    def forward(self, x, state_init):
+    def forward(self, x, state_init=None):
         x = self._rearrange_batch_dim(x)
-        seq_length = x.shape[0]
+        seq_length, batch_sz, _rest = x.shape
         if not self.cells_initialized:
             for t in range(0, seq_length):
                 self.cells.append(DPLSTMCell(self.input_size, self.hidden_size))
@@ -131,7 +131,12 @@ class DPLSTM(nn.Module):
 
         x = torch.unbind(x, dim=0)
         h = [None] * seq_length
-        h_init, c_init = state_init
+
+        if state_init:
+            h_init, c_init = state_init
+        else:
+            h_init = torch.zeros(self.num_layers, batch_sz, self.hidden_size)
+            c_init = torch.zeros(self.num_layers, batch_sz, self.hidden_size)
 
         h[0] = self.cells[0](x[0].unsqueeze(0), h_init, c_init)
         for t in range(1, seq_length):

--- a/opacus/tests/layers_grad_test.py
+++ b/opacus/tests/layers_grad_test.py
@@ -169,22 +169,15 @@ class LayersGradTest(unittest.TestCase):
 
     def test_lstm_batch_first(self):
         # input size : 25 output size : 12 minibatch : 30 sequence length : 20
-        h_init = torch.zeros(1, 30, 12)
-        c_init = torch.zeros(1, 30, 12)
-        hidden = (h_init, c_init)
-
         # Test batch_first=True case
         layer = DPLSTM(25, 12, 1, batch_first=True)
         x = torch.randn(30, 20, 25)
-        self._check_one_layer(layer, x, hidden, batch_first=True)
+        self._check_one_layer(layer, x, batch_first=True)
 
     def test_lstm_batch_second(self):
         # input size : 25 output size : 12 minibatch : 30 sequence length : 20
-        h_init = torch.zeros(1, 30, 12)
-        c_init = torch.zeros(1, 30, 12)
-        hidden = (h_init, c_init)
 
         # Test batch_first=False case
         layer = DPLSTM(25, 12, 1, batch_first=False)
         x = torch.randn(20, 30, 25)
-        self._check_one_layer(layer, x, hidden, batch_first=False)
+        self._check_one_layer(layer, x, batch_first=False)


### PR DESCRIPTION
Summary: Currently DP-LSTM always needs that you pass (h_0, c_0) to its forward, which is too stringent. With this change, we allow this to be omitted and we will put zeros of the suitable shape for you

Differential Revision: D23681436

