### PR TITLE
Add a check to _generate_noise() for clipping_value

### DIFF
--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -381,7 +381,7 @@ class PrivacyEngine:
             the generated noise with noise zero and standard
             deviation of ``noise_multiplier x max_grad_norm ``
         """
-        if self.noise_multiplier > 0:
+        if self.noise_multiplier > 0 and max_grad_norm > 0:
             return torch.normal(
                 0,
                 self.noise_multiplier * max_grad_norm,


### PR DESCRIPTION
Summary:
# Background

When DP is ON, both `noise_multiplier` and `max_grad_norm` must be greater than 0. Values less than 0 does not mean anything. Now, we can either (a) check for "invalid" inputs upon initialization (e.g. in `init()`), or (b) put checks in methods that uses those inputs.

Since for debugging and testing, it's useful to have zeros for  `noise_multiplier` and `max_grad_norm`, we have decided to go with option (b), putting checks in functions (I think :))

# Changes

This diff
- adds a check to the `_generate_noise()` method in both of our privacy engines (in Opacus, and FLSim)
  - If this check is not there, when `max_grad_norm` is zero, we get this error: `normal_ expects std > 0.0, but found std=0`
- fixes the return statement of in `_generate_noise()` UserPrivacyEngine

Reviewed By: Darktex, JohnlNguyen

Differential Revision: D23514946

