### PR TITLE
Upgrade bl version to fix security vulnerability

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
     "docusaurus": "^1.9.0"
   },
   "dependencies": {
-    "prismjs": "^1.21.0"
+    "prismjs": "^1.21.0",
+    "bl": "^1.2.3"
   }
 }


### PR DESCRIPTION
Summary:
CVE-2020-8244
high severity
Vulnerable versions: < 1.2.3
Patched version: 1.2.3
A buffer over-read vulnerability exists in bl <4.0.3, <3.0.1, <2.2.1 and <1.2.3 which could allow an attacker to supply user input (even typed) that if it ends up in consume() argument and can become negative, the BufferList state can be corrupted, tricking it into exposing uninitialized memory via regular .slice() calls.

Differential Revision: D23795274

