### PR TITLE
Add other examples to CircleCI integration tests on GPU

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
           path: unittest-reports
 
   mnist_integration_test:
-    description: "Runs MNIST end to end"
+    description: "Runs MNIST example end to end"
     parameters:
       device:
         default: "cpu"
@@ -116,12 +116,102 @@ commands:
       - run:
           name: MNIST example
           command: |
-            mkdir mnist-test-reports
-            PYTHONPATH=. python3 examples/mnist.py --lr 0.25 --sigma 0.7 -c 1.5 --batch-size 16 --epochs 2 --data-root . --n-runs 1 --device <<parameters.device>>
+            mkdir mnist
+            mkdir mnist/data
+            mkdir mnist/test-reports
+            PYTHONPATH=. python3 examples/mnist.py --lr 0.25 --sigma 0.7 -c 1.5 --batch-size 32 --epochs 1 --data-root mnist/data --n-runs 1 --device <<parameters.device>>
+          when: always
       - store_test_results:
-          path: mnist-test-reports
+          path: mnist/test-reports
       - store_artifacts:
-          path: mnist-test-reports
+          path: mnist/test-reports
+
+  cifar10_integration_test:
+    description: "Runs CIFAR10 example end to end"
+    parameters:
+      device:
+        default: "cpu"
+        type: string
+    steps:
+      - run:
+          name: CIFAR10 example
+          command: |
+            mkdir cifar10
+            mkdir cifar10/data
+            mkdir cifar10/logs
+            mkdir cifar10/test-reports
+            PYTHONPATH=. pip3 install tensorboard
+            PYTHONPATH=. python3 examples/cifar10.py --lr 0.25 --sigma 0.7 -c 1.5 --batch-size 128 --epochs 1 --data-root cifar10/data --log-dir cifar10/logs --device <<parameters.device>>
+          when: always
+      - store_test_results:
+          path: cifar10/test-reports
+      - store_artifacts:
+          path: cifar10/test-reports
+
+  dcgan_integration_test:
+    description: "Runs dcgan example end to end"
+    parameters:
+      device:
+        default: "cpu"
+        type: string
+    steps:
+      - run:
+          name: dcgan example
+          command: |
+            mkdir dcgan
+            mkdir dcgan/data
+            mkdir dcgan/test-reports
+            PYTHONPATH=. python3 examples/dcgan.py --lr 2e-4 --sigma 0.7 -c 1.5 --batch-size 32 --epochs 1 --data-root dcgan/data --device <<parameters.device>>
+          when: always
+      - store_test_results:
+          path: dcgan/test-reports
+      - store_artifacts:
+          path: dcgan/test-reports
+
+  imdb_integration_test:
+    description: "Runs imdb example end to end"
+    parameters:
+      device:
+        default: "cpu"
+        type: string
+    steps:
+      - run:
+          name: imdb example
+          command: |
+            mkdir imdb
+            mkdir imdb/data
+            mkdir imdb/test-reports
+            PYTHONPATH=. pip3 install torchtext
+            PYTHONPATH=. python3 examples/imdb.py --lr 0.02 --sigma 0.56 -c 1.0 --batch-size 16 --epochs 1 --data-root imdb/data --device <<parameters.device>>
+          when: always
+      - store_test_results:
+          path: imdb/test-reports
+      - store_artifacts:
+          path: imdb/test-reports
+
+  charlstm_integration_test:
+    description: "Runs charlstm example end to end"
+    parameters:
+      device:
+        default: "cpu"
+        type: string
+    steps:
+      - run:
+          name: charlstm example
+          command: |
+            mkdir charlstm
+            mkdir charlstm/data
+            wget https://download.pytorch.org/tutorial/data.zip -O charlstm/data/data.zip
+            unzip charlstm/data/data.zip -d charlstm/data
+            rm charlstm/data/data.zip
+            mkdir charlstm/test-reports
+            PYTHONPATH=. pip3 install scikit-learn
+            PYTHONPATH=. python3 examples/char-lstm-classification.py --data-root="charlstm/data/" --iterations 30 --learning-rate=2.0 --n-hidden=128 --delta=8e-5 --batch-size=800 --sigma=1.0 --device <<parameters.device>>
+          when: always
+      - store_test_results:
+          path: charlstm/test-reports
+      - store_artifacts:
+          path: charlstm/test-reports
 
 # -------------------------------------------------------------------------------------
 # Jobs
@@ -180,7 +270,7 @@ jobs:
       - checkout
       - pip_install
       - mnist_integration_test:
-        device: "cpu"
+          device: "cpu"
 
   integrationtest_py36_torch_release_cuda:
     machine:
@@ -191,7 +281,16 @@ jobs:
       - py_3_6_setup
       - pip_install
       - mnist_integration_test:
-        device: "cuda"
+          device: "cuda"
+      - cifar10_integration_test:
+          device: "cuda"
+      - charlstm_integration_test:
+          device: "cuda"
+      - imdb_integration_test:
+          device: "cuda"
+      - dcgan_integration_test:
+          device: "cuda"
+
 
   auto_deploy_site:
     docker:

--- a/examples/char-lstm-classification.py
+++ b/examples/char-lstm-classification.py
@@ -2,12 +2,12 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import argparse
-import glob
 import math
 import random
 import string
 import time
 import unicodedata
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -21,9 +21,7 @@ parser = argparse.ArgumentParser(
     description="PyTorch Name language classification DP Training"
 )
 parser.add_argument(
-    "--training-path",
-    type=str,
-    help="Path to training set of names (ie. /home/[username]/names/*.txt)",
+    "--data-root", type=str, help="Path to training set of names (ie. ~/data/names/)"
 )
 parser.add_argument(
     "--device",
@@ -126,7 +124,7 @@ def build_category_lines(all_filenames, all_letters):
     all_categories = []
 
     for filename in all_filenames:
-        category = filename.split("/")[-1].split(".")[0]
+        category = filename.stem
         all_categories.append(category)
         lines = read_lines(filename, all_letters)
         category_lines[category] = lines
@@ -326,8 +324,10 @@ def get_eval_metrics(
 def main():
     args = parser.parse_args()
     device = torch.device(args.device)
+    root = Path(args.data_root)
 
-    all_filenames = glob.glob(args.training_path)
+    all_filenames = list(root.glob("**/*.txt"))
+    print(f"At root {root.absolute()}, found the following files: {all_filenames}")
     all_letters = string.ascii_letters + " .,;'#"
     n_letters = len(all_letters)
 

--- a/examples/cifar10.py
+++ b/examples/cifar10.py
@@ -272,11 +272,11 @@ def main():
     # 2. enable stats
     stats.add(
         # stats about gradient norms aggregated for all layers
-        stats.Stat(stats.StatType.CLIPPING, "AllLayers", frequency=0.1),
+        stats.Stat(stats.StatType.GRAD, "AllLayers", frequency=0.1),
         # stats about gradient norms per layer
-        stats.Stat(stats.StatType.CLIPPING, "PerLayer", frequency=0.1),
+        stats.Stat(stats.StatType.GRAD, "PerLayer", frequency=0.1),
         # stats about clipping
-        stats.Stat(stats.StatType.CLIPPING, "ClippingStats", frequency=0.1),
+        stats.Stat(stats.StatType.GRAD, "ClippingStats", frequency=0.1),
         # stats on training accuracy
         stats.Stat(stats.StatType.TRAIN, "accuracy", frequency=0.01),
         # stats on validation accuracy


### PR DESCRIPTION
Summary: It's easy to make changes to Opacus and forget to update our example. We currently use only MNIST as integration test, but it is healthy to use our entire suite of examples.

Differential Revision: D24159541

