### PR TITLE
run Transformer example test on torch nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ commands:
             mkdir imdb
             mkdir imdb/data
             mkdir imdb/test-reports
-            PYTHONPATH=. pip3 install torchtext transformers
+            PYTHONPATH=. pip3 install --upgrade --pre torchtext -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
             PYTHONPATH=. python3 examples/imdb.py --lr 0.02 --sigma 0.56 -c 1.0 --batch-size 8 --max-sequence-length 256 --epochs 1 --data-root imdb/data --device <<parameters.device>>
           when: always
       - store_test_results:
@@ -293,11 +293,22 @@ jobs:
           device: "cuda"
       - cifar10_integration_test:
           device: "cuda"
-      - imdb_integration_test:
-          device: "cuda"
       - charlstm_integration_test:
           device: "cuda"
       - dcgan_integration_test:
+          device: "cuda"
+
+  integrationtest_py36_torch_nightly_cuda:
+    machine:
+      resource_class: gpu.nvidia.small
+      image: ubuntu-1604-cuda-10.1:201909-23
+    steps:
+      - checkout
+      - py_3_6_setup
+      - pip_dev_install:
+          args: "-n -c"
+      - run_nvidia_smi
+      - imdb_integration_test:
           device: "cuda"
 
 
@@ -340,6 +351,8 @@ workflows:
           filters: *exclude_ghpages
       - integrationtest_py36_torch_release_cuda:
           filters: *exclude_ghpages
+      - integrationtest_py36_torch_nightly_cuda:
+          filters: *exclude_ghpages
 
   nightly:
     triggers:
@@ -355,6 +368,8 @@ workflows:
       - integrationtest_py36_torch_release_cpu:
           filters: *exclude_ghpages
       - integrationtest_py36_torch_release_cuda:
+          filters: *exclude_ghpages
+      - integrationtest_py36_torch_nightly_cuda:
           filters: *exclude_ghpages
 
   website_deployment:

--- a/opacus/supported_layers_grad_samplers.py
+++ b/opacus/supported_layers_grad_samplers.py
@@ -281,7 +281,9 @@ def _compute_embedding_grad_sample(
         .expand(*A.shape, layer.embedding_dim)
         .reshape(batch_size, -1, layer.embedding_dim)
     )
-    grad_sample = torch.zeros(batch_size, *layer.weight.shape, device=layer.weight.device)
+    grad_sample = torch.zeros(
+        batch_size, *layer.weight.shape, device=layer.weight.device
+    )
     grad_sample.scatter_add_(1, index, B.reshape(batch_size, -1, layer.embedding_dim))
     torch.backends.cudnn.deterministic = saved
 

--- a/opacus/tests/layers_grad_test.py
+++ b/opacus/tests/layers_grad_test.py
@@ -169,7 +169,6 @@ class LayersGradTest(unittest.TestCase):
         self._check_one_layer(layer, x1)
         self._check_one_layer(layer, x2)
 
-
     def test_lstm_batch_first(self):
         # input size : 25 output size : 12 minibatch : 30 sequence length : 20
         # Test batch_first=True case

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -7,9 +7,10 @@ PYTORCH_NIGHTLY=false
 DEPLOY=false
 CHOSEN_TORCH_VERSION=-1
 
-while getopts 'ndv:' flag; do
+while getopts 'ncdv:' flag; do
   case "${flag}" in
     n) PYTORCH_NIGHTLY=true ;;
+    c) CUDA=true;;
     d) DEPLOY=true ;;
     v) CHOSEN_TORCH_VERSION=${OPTARG};;
     *) echo "usage: $0 [-n] [-d] [-v version]" >&2
@@ -45,8 +46,11 @@ sudo pip install -e .[dev]
 
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then
-  sudo pip install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-  sudo pip install --upgrade --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+  if [[ $CUDA == true ]]; then
+    sudo pip install --upgrade --pre torch torchvision torchcsprng -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
+  else
+    sudo pip install --upgrade --pre torch torchvision torchcsprng -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+  fi
 else
   # If no version specified, upgrade to latest release.
   if [[ $CHOSEN_TORCH_VERSION == -1 ]]; then


### PR DESCRIPTION
Summary:
The imdb example using Transformer is using dataset from torchtext experimental, which is a prototype and not available in stable release builds (see https://github.com/pytorch/text/releases/tag/v0.8.0-rc2)

This is causing circle ci failures. This commit runs that specific test on torch nightly. This separate run can be removed once the "Prototype" gets promoted to "Beta"

Differential Revision: D24677803

