### PR TITLE
run Transformer example test on torch nightly (#81)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,19 @@ commands:
             sudo "$(which python)" -m pip install --upgrade pip
             sudo "$(which python)" -m pip install pytest
 
+  update_gpg_key:
+    description: "Temp fix due to CircleCI image being old and requiring manual GPG key updates to Ubuntu, Nvidia, Heroku"
+    steps:
+      - run:
+          name: "Update GPG keys"
+          command: |
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+            curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
+            distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+            curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+            sudo apt-get update
+            curl https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
+
   run_nvidia_smi:
     description: "Prints GPU capabilities from nvidia-smi"
     steps:
@@ -189,7 +202,7 @@ commands:
             mkdir imdb
             mkdir imdb/data
             mkdir imdb/test-reports
-            PYTHONPATH=. pip3 install torchtext transformers
+            PYTHONPATH=. pip3 install transformers datasets
             PYTHONPATH=. python3 examples/imdb.py --lr 0.02 --sigma 0.56 -c 1.0 --batch-size 8 --max-sequence-length 256 --epochs 1 --data-root imdb/data --device <<parameters.device>>
           when: always
       - store_test_results:
@@ -231,7 +244,9 @@ jobs:
     docker:
       - image: circleci/python:3.6.9
     steps:
+      - update_gpg_key
       - checkout
+      - py_3_6_setup
       - pip_dev_install
       - lint_flake8
       - lint_black
@@ -285,6 +300,7 @@ jobs:
       resource_class: gpu.nvidia.small
       image: ubuntu-1604-cuda-10.1:201909-23
     steps:
+      - update_gpg_key
       - checkout
       - py_3_6_setup
       - pip_install
@@ -293,11 +309,23 @@ jobs:
           device: "cuda"
       - cifar10_integration_test:
           device: "cuda"
-      - imdb_integration_test:
-          device: "cuda"
       - charlstm_integration_test:
           device: "cuda"
       - dcgan_integration_test:
+          device: "cuda"
+
+  integrationtest_py36_torch_nightly_cuda:
+    machine:
+      resource_class: gpu.nvidia.small
+      image: ubuntu-1604-cuda-10.1:201909-23
+    steps:
+      - update_gpg_key
+      - checkout
+      - py_3_6_setup
+      - pip_dev_install:
+          args: "-nc"
+      - run_nvidia_smi
+      - imdb_integration_test:
           device: "cuda"
 
 
@@ -340,6 +368,8 @@ workflows:
           filters: *exclude_ghpages
       - integrationtest_py36_torch_release_cuda:
           filters: *exclude_ghpages
+      - integrationtest_py36_torch_nightly_cuda:
+          filters: *exclude_ghpages
 
   nightly:
     triggers:
@@ -355,6 +385,8 @@ workflows:
       - integrationtest_py36_torch_release_cpu:
           filters: *exclude_ghpages
       - integrationtest_py36_torch_release_cuda:
+          filters: *exclude_ghpages
+      - integrationtest_py36_torch_nightly_cuda:
           filters: *exclude_ghpages
 
   website_deployment:

--- a/opacus/supported_layers_grad_samplers.py
+++ b/opacus/supported_layers_grad_samplers.py
@@ -268,7 +268,9 @@ def _compute_embedding_grad_sample(
         .expand(*A.shape, layer.embedding_dim)
         .reshape(batch_size, -1, layer.embedding_dim)
     )
-    grad_sample = torch.zeros(batch_size, *layer.weight.shape, device=layer.weight.device)
+    grad_sample = torch.zeros(
+        batch_size, *layer.weight.shape, device=layer.weight.device
+    )
     grad_sample.scatter_add_(1, index, B.reshape(batch_size, -1, layer.embedding_dim))
     torch.backends.cudnn.deterministic = saved
 

--- a/opacus/tests/layers_grad_test.py
+++ b/opacus/tests/layers_grad_test.py
@@ -169,7 +169,6 @@ class LayersGradTest(unittest.TestCase):
         self._check_one_layer(layer, x1)
         self._check_one_layer(layer, x2)
 
-
     def test_lstm_batch_first(self):
         # input size : 25 output size : 12 minibatch : 30 sequence length : 20
         # Test batch_first=True case


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/opacus/pull/81

The imdb example using Transformer is using dataset from torchtext experimental, which is a prototype and not available in stable release builds (see https://github.com/pytorch/text/releases/tag/v0.8.0-rc2)

This is causing circle ci failures. This commit runs that specific test on torch nightly. This separate run can be removed once the "Prototype" gets promoted to "Beta"

Differential Revision: D24677803

