### PR TITLE
Make TorchCSPRNG an optional dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,7 @@ jobs:
     steps:
       - checkout
       - pip_install
+      - run: pip install torchcsprng
       - unit_tests
 
   unittest_py37_torch_release:
@@ -276,6 +277,7 @@ jobs:
     steps:
       - checkout
       - pip_install
+      - run: pip install torchcsprng
       - unit_tests
 
   unittest_py38_torch_release:
@@ -284,6 +286,7 @@ jobs:
     steps:
       - checkout
       - pip_install
+      - run: pip install torchcsprng
       - unit_tests
 
   unittest_py38_torch_nightly:

--- a/examples/dcgan.py
+++ b/examples/dcgan.py
@@ -17,7 +17,6 @@ import torch.nn as nn
 import torch.nn.parallel
 import torch.optim as optim
 import torch.utils.data
-import torchcsprng as prng
 import torchvision.datasets as dset
 import torchvision.transforms as transforms
 import torchvision.utils as vutils
@@ -149,9 +148,20 @@ try:
 except ValueError:
     print("Cannot load dataset")
 
-generator = (
-    prng.create_random_device_generator("/dev/urandom") if opt.secure_rng else None
-)
+if opt.secure_rng:
+    try:
+        import torchcsprng as prng
+    except ImportError as e:
+        msg = (
+            "To use secure RNG, you must install the torchcsprng package! "
+            "Check out the instructions here: https://github.com/pytorch/csprng#installation"
+        )
+        raise ImportError(msg) from e
+
+    generator = prng.create_random_device_generator("/dev/urandom")
+
+else:
+    generator = None
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=opt.batch_size,

--- a/examples/imdb.py
+++ b/examples/imdb.py
@@ -11,7 +11,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
-import torchcsprng as prng
 from datasets import load_dataset
 from opacus import PrivacyEngine
 from torch.functional import F
@@ -227,9 +226,20 @@ def main():
     train_dataset = dataset["train"]
     test_dataset = dataset["test"]
 
-    generator = (
-        prng.create_random_device_generator("/dev/urandom") if args.secure_rng else None
-    )
+    if args.secure_rng:
+        try:
+            import torchcsprng as prng
+        except ImportError as e:
+            msg = (
+                "To use secure RNG, you must install the torchcsprng package! "
+                "Check out the instructions here: https://github.com/pytorch/csprng#installation"
+            )
+            raise ImportError(msg) from e
+
+        generator = prng.create_random_device_generator("/dev/urandom")
+
+    else:
+        generator = None
 
     train_loader = DataLoader(
         train_dataset,

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -7,7 +7,6 @@ import warnings
 from typing import List, Optional, Tuple, Union
 
 import torch
-import torchcsprng as csprng
 from torch import nn
 
 from . import privacy_analysis as tf_privacy
@@ -95,6 +94,15 @@ class PrivacyEngine:
             )
 
         if self.secure_rng:
+            try:
+                import torchcsprng as csprng
+            except ImportError as e:
+                msg = (
+                    "To use secure RNG, you must install the torchcsprng package! "
+                    "Check out the instructions here: https://github.com/pytorch/csprng#installation"
+                )
+                raise ImportError(msg) from e
+
             self.seed = None
             self.random_number_generator = csprng.create_random_device_generator(
                 "/dev/urandom"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ torchvision>=0.4
 tqdm>=4.40
 scipy>=1.2
 pytest
-torchcsprng>=0.1.2

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ DEV_REQUIRES = [
     "sphinx-autodoc-typehints",
     "mypy>=0.760",
     "isort",
+    "torchcsprng",
 ]
 
 


### PR DESCRIPTION
Summary:
Secure shuffling is a feature that comes at a high performance cost and makes pip imports harder. Given we expect most users to use it only once to train a final model, it makes sense to move it to an external dep.

This will simplify Colab imports a lot.

Differential Revision: D25593388

