### PR TITLE
Extend DPLSTM to work with torch < 1.6

### DIFF
--- a/opacus/layers/param_rename.py
+++ b/opacus/layers/param_rename.py
@@ -6,7 +6,7 @@ from typing import Dict, Union
 
 import torch.nn as nn
 from torch import Tensor
-from torch.nn.modules.module import ModuleAttributeError, _IncompatibleKeys
+from torch.nn.modules.module import _IncompatibleKeys
 
 
 def filter_out_old_keys(self, state_dict, prefix, local_metadata):
@@ -65,7 +65,7 @@ class ParamRenamedModule(nn.Module):
         super().__setattr__(name, value)
         try:
             self._register_renamed_parameters()
-        except ModuleAttributeError:
+        except AttributeError:
             # At the very beginning of instantiation, this will fail because we do not yet have
             # self._parameters. Safe to ignore.
             pass


### PR DESCRIPTION
Summary:
ParamRenameModule needs to check and ignore ModuleAttributeErrors when first instantiated due to implementation details.

ModuleAttributeErrors were first introduced in torch 1.6, but are still subclassing AttributeError. We can safely use AttributeError here and retain compatibility with torch 1.5 which is still less than a year old.

Reviewed By: karthikprasad

Differential Revision: D25796628

