### PR TITLE
Put the model in train mode in the text classifier tutorial

### DIFF
--- a/tutorials/building_text_classifier.ipynb
+++ b/tutorials/building_text_classifier.ipynb
@@ -560,6 +560,8 @@
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "model = model.to(device)\n",
     "\n",
+    "# Set the model to train mode (HuggingFace models load in eval mode)\n",
+    "model = model.train()\n"
     "# Define optimizer\n",
     "optimizer = torch.optim.AdamW(model.parameters(), lr=5e-4, eps=1e-8)"
    ]


### PR DESCRIPTION
Summary: PrivacyEngine wants modules to be in train mode, otherwise you may get an obscure err

Reviewed By: karthikprasad

Differential Revision: D25858498

