### PR TITLE
Remove the name of privacy_analysis import

### DIFF
--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple, Union
 import torch
 from torch import nn
 
-from . import privacy_analysis as tf_privacy
+from . import privacy_analysis
 from .dp_model_inspector import DPModelInspector
 from .per_sample_gradient_clip import PerSampleGradientClipper
 from .utils import clipping
@@ -204,7 +204,7 @@ class PrivacyEngine:
 
     def get_renyi_divergence(self):
         rdp = torch.tensor(
-            tf_privacy.compute_rdp(
+            privacy_analysis.compute_rdp(
                 self.sample_rate, self.noise_multiplier, 1, self.alphas
             )
         )
@@ -230,7 +230,7 @@ class PrivacyEngine:
         if target_delta is None:
             target_delta = self.target_delta
         rdp = self.get_renyi_divergence() * self.steps
-        return tf_privacy.get_privacy_spent(self.alphas, rdp, target_delta)
+        return privacy_analysis.get_privacy_spent(self.alphas, rdp, target_delta)
 
     def zero_grad(self):
         """

--- a/opacus/scripts/compute_dp_sgd_privacy.py
+++ b/opacus/scripts/compute_dp_sgd_privacy.py
@@ -22,7 +22,7 @@ import argparse
 import math
 from typing import List, Tuple
 
-from opacus import privacy_analysis as tf_privacy
+from opacus import privacy_analysis
 
 
 def _apply_dp_sgd_analysis(
@@ -49,8 +49,8 @@ def _apply_dp_sgd_analysis(
     Returns:
         Pair of privacy loss epsilon and optimal order alpha
     """
-    rdp = tf_privacy.compute_rdp(sample_rate, noise_multiplier, steps, alphas)
-    eps, opt_alpha = tf_privacy.get_privacy_spent(alphas, rdp, delta=delta)
+    rdp = privacy_analysis.compute_rdp(sample_rate, noise_multiplier, steps, alphas)
+    eps, opt_alpha = privacy_analysis.get_privacy_spent(alphas, rdp, delta=delta)
 
     if verbose:
         print(


### PR DESCRIPTION
Summary:
This diff removes the name `tf_privacy` from the `privacy_analysis` import.

The reference and credit for the original code (TFP) is already included in the `privacy_analysis.py`

Differential Revision: D25730102

