### PR TITLE
Added PackedSequence support in DPLSTM

### DIFF
--- a/opacus/autograd_grad_sample.py
+++ b/opacus/autograd_grad_sample.py
@@ -18,7 +18,6 @@ from typing import Tuple
 
 import torch
 import torch.nn as nn
-
 from opacus.layers.dp_lstm import LSTMLinear
 
 from .supported_layers_grad_samplers import _supported_layers_grad_samplers

--- a/opacus/autograd_grad_sample.py
+++ b/opacus/autograd_grad_sample.py
@@ -218,7 +218,10 @@ def _compute_grad_sample(
     else:
         A = layer.activations
 
-    n = A.shape[batch_dim]
+    if not hasattr(layer, 'max_batch_len'):
+        layer.max_batch_len = _get_batch_size(layer, A, batch_dim)
+
+    n = layer.max_batch_len
     if loss_reduction == "mean":
         B = backprops * n
     elif loss_reduction == "sum":
@@ -238,4 +241,24 @@ def _compute_grad_sample(
     )
 
     compute_layer_grad_sample(layer, A, B)        
+
+    if (not isinstance(layer.activations, list) or len(layer.activations) == 0) and hasattr(layer, 'max_batch_len'):
+        del layer.max_batch_len
+
+
+def _get_batch_size(layer: nn.Module, grad_sample: torch.Tensor, batch_dim: int) -> int:
+    r"""
+    Computes and returns the maximum batch size which is the maximum of the dimension values
+    along 'batch_dim' axis over layer.activations + [grad_sample], where layer.activations is 
+    a list. If layer.activations is a not a list, then return grad_sample.shape[batch_dim]. 
+    """
+    
+    max_batch_len = 0
+    if isinstance(layer.activations, list):
+        for out in layer.activations:
+            if out.shape[batch_dim] > max_batch_len:
+                max_batch_len = out.shape[batch_dim]
+
+    max_batch_len = max(max_batch_len, grad_sample.shape[batch_dim])
+    return max_batch_len
 

--- a/opacus/autograd_grad_sample.py
+++ b/opacus/autograd_grad_sample.py
@@ -218,7 +218,7 @@ def _compute_grad_sample(
     else:
         A = layer.activations
 
-    if not hasattr(layer, 'max_batch_len'):
+    if not hasattr(layer, "max_batch_len"):
         layer.max_batch_len = _get_batch_size(layer, A, batch_dim)
 
     n = layer.max_batch_len
@@ -240,19 +240,21 @@ def _compute_grad_sample(
         get_layer_type(layer)
     )
 
-    compute_layer_grad_sample(layer, A, B)        
+    compute_layer_grad_sample(layer, A, B)
 
-    if (not isinstance(layer.activations, list) or len(layer.activations) == 0) and hasattr(layer, 'max_batch_len'):
+    if (
+        not isinstance(layer.activations, list) or len(layer.activations) == 0
+    ) and hasattr(layer, "max_batch_len"):
         del layer.max_batch_len
 
 
 def _get_batch_size(layer: nn.Module, grad_sample: torch.Tensor, batch_dim: int) -> int:
     r"""
     Computes and returns the maximum batch size which is the maximum of the dimension values
-    along 'batch_dim' axis over layer.activations + [grad_sample], where layer.activations is 
-    a list. If layer.activations is a not a list, then return grad_sample.shape[batch_dim]. 
+    along 'batch_dim' axis over layer.activations + [grad_sample], where layer.activations is
+    a list. If layer.activations is a not a list, then return grad_sample.shape[batch_dim].
     """
-    
+
     max_batch_len = 0
     if isinstance(layer.activations, list):
         for out in layer.activations:
@@ -261,4 +263,3 @@ def _get_batch_size(layer: nn.Module, grad_sample: torch.Tensor, batch_dim: int)
 
     max_batch_len = max(max_batch_len, grad_sample.shape[batch_dim])
     return max_batch_len
-

--- a/opacus/autograd_grad_sample.py
+++ b/opacus/autograd_grad_sample.py
@@ -23,8 +23,6 @@ from opacus.layers.dp_lstm import LSTMLinear
 from .supported_layers_grad_samplers import _supported_layers_grad_samplers
 from .utils.module_inspection import get_layer_type, requires_grad
 
-from inspect import signature
-
 # work-around for https://github.com/pytorch/pytorch/issues/25723
 _hooks_disabled: bool = False
 
@@ -239,25 +237,5 @@ def _compute_grad_sample(
         get_layer_type(layer)
     )
 
-    if 'max_batch_len' in signature(compute_layer_grad_sample).parameters: # For compatibility with PackedSequences
-        max_batch_len = _get_batch_size(layer, A, batch_dim)
-        compute_layer_grad_sample(layer, A, B, max_batch_len=max_batch_len)
-    else:
-        compute_layer_grad_sample(layer, A, B)        
+    compute_layer_grad_sample(layer, A, B)        
 
-
-def _get_batch_size(layer, A, batch_dim):
-    if batch_dim != 0:
-        return 0
-
-    if hasattr(layer, 'max_batch_len'):
-        return layer.max_batch_len
-
-    max_batch_len = 0
-    for out in layer.activations:
-        if out.shape[0] > max_batch_len:
-            max_batch_len = out.shape[0]
-
-    max_batch_len = max(max_batch_len, A.shape[batch_dim])
-    layer.max_batch_len = max_batch_len
-    return max_batch_len

--- a/opacus/autograd_grad_sample.py
+++ b/opacus/autograd_grad_sample.py
@@ -23,6 +23,7 @@ from opacus.layers.dp_lstm import LSTMLinear
 from .supported_layers_grad_samplers import _supported_layers_grad_samplers
 from .utils.module_inspection import get_layer_type, requires_grad
 
+
 # work-around for https://github.com/pytorch/pytorch/issues/25723
 _hooks_disabled: bool = False
 

--- a/opacus/autograd_grad_sample.py
+++ b/opacus/autograd_grad_sample.py
@@ -23,6 +23,7 @@ from opacus.layers.dp_lstm import LSTMLinear
 from .supported_layers_grad_samplers import _supported_layers_grad_samplers
 from .utils.module_inspection import get_layer_type, requires_grad
 
+from inspect import signature
 
 # work-around for https://github.com/pytorch/pytorch/issues/25723
 _hooks_disabled: bool = False
@@ -214,7 +215,6 @@ def _compute_grad_sample(
 
     # Outside of the LSTM there is "batch_first" but not for the Linear inside the LSTM
     batch_dim = 0 if batch_first or type(layer) is LSTMLinear else 1
-
     if isinstance(layer.activations, list):
         A = layer.activations.pop()
     else:
@@ -238,4 +238,26 @@ def _compute_grad_sample(
     compute_layer_grad_sample = _supported_layers_grad_samplers.get(
         get_layer_type(layer)
     )
-    compute_layer_grad_sample(layer, A, B)
+
+    if 'max_batch_len' in signature(compute_layer_grad_sample).parameters: # For compatibility with PackedSequences
+        max_batch_len = _get_batch_size(layer, A, batch_dim)
+        compute_layer_grad_sample(layer, A, B, max_batch_len=max_batch_len)
+    else:
+        compute_layer_grad_sample(layer, A, B)        
+
+
+def _get_batch_size(layer, A, batch_dim):
+    if batch_dim != 0:
+        return 0
+
+    if hasattr(layer, 'max_batch_len'):
+        return layer.max_batch_len
+
+    max_batch_len = 0
+    for out in layer.activations:
+        if out.shape[0] > max_batch_len:
+            max_batch_len = out.shape[0]
+
+    max_batch_len = max(max_batch_len, A.shape[batch_dim])
+    layer.max_batch_len = max_batch_len
+    return max_batch_len

--- a/opacus/autograd_grad_sample.py
+++ b/opacus/autograd_grad_sample.py
@@ -18,6 +18,7 @@ from typing import Tuple
 
 import torch
 import torch.nn as nn
+
 from opacus.layers.dp_lstm import LSTMLinear
 
 from .supported_layers_grad_samplers import _supported_layers_grad_samplers

--- a/opacus/layers/dp_lstm.py
+++ b/opacus/layers/dp_lstm.py
@@ -159,16 +159,16 @@ class DPLSTMCell(nn.Module):
         )
         i_t = torch.sigmoid(
             i_t_input
-        )  # [B, D] or [batch_size_t, 4*D] if batch_size_t is not None
+        )  # [B, D] or [batch_size_t, D] if batch_size_t is not None
         f_t = torch.sigmoid(
             f_t_input
-        )  # [B, D] or [batch_size_t, 4*D] if batch_size_t is not None
+        )  # [B, D] or [batch_size_t, D] if batch_size_t is not None
         g_t = torch.tanh(
             g_t_input
-        )  # [B, D] or [batch_size_t, 4*D] if batch_size_t is not None
+        )  # [B, D] or [batch_size_t, D] if batch_size_t is not None
         o_t = torch.sigmoid(
             o_t_input
-        )  # [B, D] or [batch_size_t, 4*D] if batch_size_t is not None
+        )  # [B, D] or [batch_size_t, D] if batch_size_t is not None
         if batch_size_t is None:
             c_t = f_t * c_prev + i_t * g_t
         else:

--- a/opacus/layers/dp_lstm.py
+++ b/opacus/layers/dp_lstm.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
-from torch.nn.utils.rnn import (PackedSequence, pack_padded_sequence,
-                                pad_sequence)
+from torch.nn.utils.rnn import PackedSequence, pack_padded_sequence, pad_sequence
 
 from .param_rename import ParamRenamedModule
 

--- a/opacus/layers/dp_lstm.py
+++ b/opacus/layers/dp_lstm.py
@@ -80,6 +80,7 @@ def _concat_sequence_directions(
     Args:
         forward: list/tuple containing n tensors, representing the output of the forward layer.
         reverse: list/tuple containing n tensors, representing the output of the backward layer.
+        dim: the dimension along which the sequence of tensors within forward and reverse will be concatenated.
     Returns:
         output: list/tuple containing n concatenated tensors.
     """
@@ -454,8 +455,6 @@ class DPLSTM(ParamRenamedModule):
         if isinstance(x, PackedSequence):
             x, batch_sizes, sorted_indices, unsorted_indices = x
             B = batch_sizes[0].item()
-            seq_length = batch_sizes.size(0)
-            batch_sz = None
             _, D = x.shape
             x = x.split(tuple(batch_sizes))
         else:

--- a/opacus/layers/dp_lstm.py
+++ b/opacus/layers/dp_lstm.py
@@ -3,11 +3,10 @@ from typing import List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
-from torch.nn.utils.rnn import PackedSequence
+from torch.nn.utils.rnn import (PackedSequence, pack_padded_sequence,
+                                pad_sequence)
 
 from .param_rename import ParamRenamedModule
-
-from torch.nn.utils.rnn import pad_sequence, pack_padded_sequence
 
 
 def _compute_seq_lengths(batch_sizes: torch.Tensor) -> List[int]:

--- a/opacus/layers/dp_lstm.py
+++ b/opacus/layers/dp_lstm.py
@@ -3,7 +3,8 @@ from typing import List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
-from torch.nn.utils.rnn import PackedSequence, pack_padded_sequence, pad_sequence
+from torch.nn.utils.rnn import (PackedSequence, pack_padded_sequence,
+                                pad_sequence)
 
 from .param_rename import ParamRenamedModule
 

--- a/opacus/supported_layers_grad_samplers.py
+++ b/opacus/supported_layers_grad_samplers.py
@@ -287,16 +287,6 @@ def _compute_embedding_grad_sample(
     _create_or_extend_grad_sample(layer.weight, grad_sample, batch_dim)
 
 
-def _get_batch_size(layer, grad_sample):
-    max_batch_len = 0
-    for out in layer.activations:
-        if out.shape[0] > max_batch_len:
-            max_batch_len = out.shape[0]
-
-    max_batch_len = max(max_batch_len, grad_sample.shape[0])
-    return max_batch_len
-
-
 _supported_layers_grad_samplers = {
     "Embedding": _compute_embedding_grad_sample,
     "Linear": _compute_linear_grad_sample,

--- a/opacus/supported_layers_grad_samplers.py
+++ b/opacus/supported_layers_grad_samplers.py
@@ -60,17 +60,11 @@ def _create_or_accumulate_grad_sample(
     """
 
     max_batch_len = _get_batch_size(layer, grad_sample)
-    if max_batch_len > 0:
-        if hasattr(param, "grad_sample"):
-            param.grad_sample[:grad_sample.shape[0]] += grad_sample
-        else:
-            param.grad_sample = torch.zeros(torch.Size([max_batch_len]) + grad_sample.shape[1:])
-            param.grad_sample[:grad_sample.shape[0]] = grad_sample        
+    if hasattr(param, "grad_sample"):
+        param.grad_sample[:grad_sample.shape[0]] += grad_sample
     else:
-        if hasattr(param, "grad_sample"):
-            param.grad_sample += grad_sample
-        else:
-            param.grad_sample = grad_sample.clone()
+        param.grad_sample = torch.zeros(torch.Size([max_batch_len]) + grad_sample.shape[1:])
+        param.grad_sample[:grad_sample.shape[0]] = grad_sample        
 
 
 def _compute_linear_grad_sample(

--- a/opacus/supported_layers_grad_samplers.py
+++ b/opacus/supported_layers_grad_samplers.py
@@ -63,7 +63,7 @@ def _create_or_accumulate_grad_sample(
         param.grad_sample[:grad_sample.shape[0]] += grad_sample
     else:
         max_batch_len = layer.max_batch_len
-        param.grad_sample = torch.zeros(torch.Size([max_batch_len]) + grad_sample.shape[1:])
+        param.grad_sample = torch.zeros(torch.Size([max_batch_len]) + grad_sample.shape[1:], device=grad_sample.device)
         param.grad_sample[:grad_sample.shape[0]] = grad_sample        
 
 def _compute_linear_grad_sample(

--- a/opacus/supported_layers_grad_samplers.py
+++ b/opacus/supported_layers_grad_samplers.py
@@ -23,7 +23,6 @@ from torch.functional import F
 from .utils.module_inspection import get_layer_type
 from .utils.tensor_utils import sum_over_all_but_batch_and_last_n, unfold3d
 
-
 def _create_or_extend_grad_sample(
     param: torch.Tensor, grad_sample: torch.Tensor, batch_dim: int
 ) -> None:
@@ -46,7 +45,7 @@ def _create_or_extend_grad_sample(
 
 
 def _create_or_accumulate_grad_sample(
-    param: torch.Tensor, grad_sample: torch.Tensor, batch_dim: int, layer
+    param: torch.Tensor, grad_sample: torch.Tensor, batch_dim: int, layer: LSTMLinear, max_batch_len: int
 ) -> None:
     """
     Creates a ``grad_sample`` attribute in the given parameter, or adds to it
@@ -59,10 +58,18 @@ def _create_or_accumulate_grad_sample(
         batch_dim: Position of the batch dimension in the shape of
             ``grad_sample``
     """
-    if hasattr(param, "grad_sample"):
-        param.grad_sample += grad_sample
+    if max_batch_len > 0:
+        if hasattr(param, "grad_sample"):
+            param.grad_sample[:grad_sample.shape[0]] += grad_sample
+        else:
+            param.grad_sample = torch.zeros(torch.Size([max_batch_len]) + grad_sample.shape[1:])
+            param.grad_sample[:grad_sample.shape[0]] = grad_sample        
     else:
-        param.grad_sample = grad_sample.clone()
+        if hasattr(param, "grad_sample"):
+            param.grad_sample += grad_sample
+        else:
+            print("clonning!")
+            param.grad_sample = grad_sample.clone()
 
 
 def _compute_linear_grad_sample(
@@ -70,7 +77,6 @@ def _compute_linear_grad_sample(
 ) -> None:
     """
     Computes per sample gradients for ``nn.Linear`` layer
-
     Args:
         layer: Layer
         A: Activations
@@ -91,7 +97,7 @@ def _compute_linear_grad_sample(
 
 
 def _compute_accumulate_linear_grad_sample(
-    layer: LSTMLinear, A: torch.Tensor, B: torch.Tensor, batch_dim: int = 0
+    layer: LSTMLinear, A: torch.Tensor, B: torch.Tensor, batch_dim: int = 0, max_batch_len: int = 0
 ) -> None:
     """
     Computes per sample gradients for ``LSTMLinear`` layer
@@ -104,8 +110,10 @@ def _compute_accumulate_linear_grad_sample(
     """
 
     gs = torch.einsum("n...i,n...j->n...ij", B, A)
+    # print("gs_shape:", gs.shape)
+    # print(gs.shape,torch.einsum("n...ij->nij", gs).shape,torch.einsum("n...k->nk", B).shape)
     _create_or_accumulate_grad_sample(
-        layer.weight, torch.einsum("n...ij->nij", gs), batch_dim, layer
+        layer.weight, torch.einsum("n...ij->nij", gs), batch_dim, layer, max_batch_len
     )
 
     if layer.bias is not None:
@@ -114,6 +122,7 @@ def _compute_accumulate_linear_grad_sample(
             torch.einsum("n...k->nk", B),
             batch_dim,
             layer,
+            max_batch_len,
         )
 
 

--- a/opacus/supported_layers_grad_samplers.py
+++ b/opacus/supported_layers_grad_samplers.py
@@ -23,6 +23,7 @@ from torch.functional import F
 from .utils.module_inspection import get_layer_type
 from .utils.tensor_utils import sum_over_all_but_batch_and_last_n, unfold3d
 
+
 def _create_or_extend_grad_sample(
     param: torch.Tensor, grad_sample: torch.Tensor, batch_dim: int
 ) -> None:
@@ -60,11 +61,15 @@ def _create_or_accumulate_grad_sample(
     """
 
     if hasattr(param, "grad_sample"):
-        param.grad_sample[:grad_sample.shape[0]] += grad_sample
+        param.grad_sample[: grad_sample.shape[0]] += grad_sample
     else:
         max_batch_len = layer.max_batch_len
-        param.grad_sample = torch.zeros(torch.Size([max_batch_len]) + grad_sample.shape[1:], device=grad_sample.device)
-        param.grad_sample[:grad_sample.shape[0]] = grad_sample        
+        param.grad_sample = torch.zeros(
+            torch.Size([max_batch_len]) + grad_sample.shape[1:],
+            device=grad_sample.device,
+        )
+        param.grad_sample[: grad_sample.shape[0]] = grad_sample
+
 
 def _compute_linear_grad_sample(
     layer: nn.Linear, A: torch.Tensor, B: torch.Tensor, batch_dim: int = 0

--- a/opacus/supported_layers_grad_samplers.py
+++ b/opacus/supported_layers_grad_samplers.py
@@ -59,13 +59,12 @@ def _create_or_accumulate_grad_sample(
             ``grad_sample``
     """
 
-    max_batch_len = _get_batch_size(layer, grad_sample)
     if hasattr(param, "grad_sample"):
         param.grad_sample[:grad_sample.shape[0]] += grad_sample
     else:
+        max_batch_len = layer.max_batch_len
         param.grad_sample = torch.zeros(torch.Size([max_batch_len]) + grad_sample.shape[1:])
         param.grad_sample[:grad_sample.shape[0]] = grad_sample        
-
 
 def _compute_linear_grad_sample(
     layer: nn.Linear, A: torch.Tensor, B: torch.Tensor, batch_dim: int = 0

--- a/opacus/tests/dp_layers/common.py
+++ b/opacus/tests/dp_layers/common.py
@@ -3,13 +3,14 @@
 
 import io
 import unittest
-from typing import Callable, Optional, Sequence, Tuple
+from typing import Callable, Optional, Sequence, Tuple, Union, List
 
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.testing import assert_allclose
+from torch.nn.utils.rnn import PackedSequence, pad_packed_sequence
 
 
 def clone_module(module: nn.Module) -> nn.Module:
@@ -43,7 +44,7 @@ def flatten(seq: Sequence) -> Sequence:
 
     def _flatten(seq, a):
         for i in seq:
-            if isinstance(i, Sequence):
+            if isinstance(i, Sequence) and not isinstance(i, PackedSequence):
                 _flatten(i, a)
             else:
                 a.append(i)
@@ -82,6 +83,8 @@ class DPModules_test(unittest.TestCase):
     outputs and states are the same between the two implementations. Here, we do NOT test for
     grad_samples, which is something we do in the grad_sample tests.
     """
+
+    batch_first_nn, batch_first_dp = None, None
 
     def compare_forward_outputs(
         self,
@@ -122,6 +125,11 @@ class DPModules_test(unittest.TestCase):
         torch.manual_seed(0)
         np.random.seed(0)
 
+        batch_first_nn, batch_first_dp = (
+            getattr(nn_module, "batch_first", None),
+            getattr(dp_module, "batch_first", None),
+        )
+
         nn_outs = nn_module(*module_args, **module_kwargs)
         nn_len = 0
         try:
@@ -146,7 +154,15 @@ class DPModules_test(unittest.TestCase):
         )
 
         self._check_shapes(nn_outs, dp_outs, output_names=output_names)
-        self._check_values(nn_outs, dp_outs, atol, rtol, output_names=output_names)
+        self._check_values(
+            nn_outs,
+            dp_outs,
+            atol,
+            rtol,
+            output_names=output_names,
+            batch_first_nn=batch_first_nn,
+            batch_first_dp=batch_first_dp,
+        )
 
     def compare_gradients(
         self,
@@ -227,8 +243,8 @@ class DPModules_test(unittest.TestCase):
 
     def _check_shapes(
         self,
-        nn_outs: Tuple[torch.Tensor],
-        dp_outs: Tuple[torch.Tensor],
+        nn_outs: Tuple[Union[torch.Tensor, PackedSequence]],
+        dp_outs: Tuple[Union[torch.Tensor, PackedSequence]],
         output_names: Optional[Tuple[str]] = None,
     ) -> None:
         output_names = output_names or [None] * len(nn_outs)
@@ -237,13 +253,15 @@ class DPModules_test(unittest.TestCase):
             zip(output_names, nn_outs, dp_outs)
         ):
             name = f"'{out_name}'" or f"#{i}"
+            if not torch.is_tensor(nn_out):
+                continue  # Won't have a shape, and value check between nontensors is done in self._check_values()
+
             msg = (
                 f"Output {name}: "
                 f"from our DP module: {dp_out.shape}, "
                 f"from reference nn.Module: {nn_out.shape}. "
             )
-            if not torch.is_tensor(nn_out):
-                continue  # Won't have a shape, and value check between nontensors is done in self._check_values()
+
             try:
                 self.assertEqual(
                     dp_out.shape,
@@ -262,11 +280,13 @@ class DPModules_test(unittest.TestCase):
 
     def _check_values(
         self,
-        nn_outs: Tuple[torch.Tensor],
-        dp_outs: Tuple[torch.Tensor],
+        nn_outs: Tuple[Union[torch.Tensor, PackedSequence]],
+        dp_outs: Tuple[Union[torch.Tensor, PackedSequence]],
         atol: float,
         rtol: float,
         output_names: Optional[Tuple[str]] = None,
+        batch_first_nn: Optional[bool] = None,
+        batch_first_dp: Optional[bool] = None,
     ) -> None:
         output_names = output_names or [None] * len(nn_outs)
         failed = []
@@ -274,6 +294,19 @@ class DPModules_test(unittest.TestCase):
             zip(output_names, nn_outs, dp_outs)
         ):
             name = f"'{out_name}'" or f"#{i}"
+
+            if isinstance(nn_out, PackedSequence):
+                self._check_packed_sequence(
+                    name,
+                    nn_out,
+                    dp_out,
+                    batch_first_nn,
+                    batch_first_dp,
+                    atol,
+                    rtol,
+                    failed,
+                )
+                continue
 
             msg = (
                 f"Output {name}: DP module L2 norm = : {dp_out.norm(2)}, ",
@@ -295,3 +328,53 @@ class DPModules_test(unittest.TestCase):
             raise AssertionError(
                 f"A total of {len(failed)} values do not match:\n\t{failed_str}"
             )
+
+    def _check_packed_sequence(
+        self,
+        name: str,
+        nn_out: PackedSequence,
+        dp_out: PackedSequence,
+        batch_first_nn: bool,
+        batch_first_dp: bool,
+        atol: float,
+        rtol: float,
+        failure_msgs: Optional[Sequence] = None,
+    ) -> bool:
+
+        try:
+            padded_seq_nn, seq_lens_nn = pad_packed_sequence(nn_out, batch_first_nn)
+        except ValueError:
+            raise ValueError("Incorrect format of the nn.module output PackedSequence")
+
+        try:
+            padded_seq_dp, seq_lens_dp = pad_packed_sequence(dp_out, batch_first_dp)
+        except ValueError:
+            raise ValueError("Incorrect format of the DP module output PackedSequence")
+
+        self._check_shapes(
+            (padded_seq_nn, seq_lens_nn),
+            (padded_seq_dp, seq_lens_dp),
+            ("padded_sequence", "batch_sequence_lengths"),
+        )
+
+        msg = (
+            f"Output PackedSequence {name}: DP module padded sequence L2 norm = {padded_seq_dp.norm(2)}, ",
+            f"Reference nn.Module padded sequence L2 norm = {padded_seq_nn.norm(2)}, ",
+            f"MSE = {F.mse_loss(padded_seq_dp, padded_seq_nn)}, ",
+            f"L1 Loss = {F.l1_loss(padded_seq_dp, padded_seq_nn)}",
+            f"Manhattan distance (L1) between batch sequence lengths = {(seq_lens_nn - seq_lens_dp).abs().sum()}",  # F.l1_loss is for floats, so we are computing this manually.
+        )
+
+        try:
+            assert_allclose(
+                actual=padded_seq_dp, expected=padded_seq_nn, atol=atol, rtol=rtol
+            )
+            assert_allclose(
+                actual=seq_lens_dp, expected=seq_lens_nn, atol=atol, rtol=rtol
+            )
+        except AssertionError:
+            if failure_msgs is not None:
+                failure_msgs.append(msg)
+            return False
+
+        return True

--- a/opacus/tests/dp_layers/common.py
+++ b/opacus/tests/dp_layers/common.py
@@ -9,8 +9,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.testing import assert_allclose
 from torch.nn.utils.rnn import PackedSequence, pad_packed_sequence
+from torch.testing import assert_allclose
 
 
 def clone_module(module: nn.Module) -> nn.Module:

--- a/opacus/tests/dp_layers/common.py
+++ b/opacus/tests/dp_layers/common.py
@@ -3,7 +3,7 @@
 
 import io
 import unittest
-from typing import Callable, Optional, Sequence, Tuple, Union, List
+from typing import Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch

--- a/opacus/tests/dp_layers/dp_lstm_test.py
+++ b/opacus/tests/dp_layers/dp_lstm_test.py
@@ -8,10 +8,10 @@ import torch
 import torch.nn as nn
 from hypothesis import given, settings
 from opacus.layers import DPLSTM
+from opacus.utils.packed_sequences import _gen_packed_data
 from torch.nn.utils.rnn import PackedSequence
 
 from .common import DPModules_test
-from opacus.utils.packed_sequences import _gen_packed_data
 
 
 def lstm_train_fn(

--- a/opacus/tests/dp_layers/dp_lstm_test.py
+++ b/opacus/tests/dp_layers/dp_lstm_test.py
@@ -1,27 +1,33 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import hypothesis.strategies as st
 import torch
 import torch.nn as nn
 from hypothesis import given, settings
 from opacus.layers import DPLSTM
+from torch.nn.utils.rnn import PackedSequence
 
 from .common import DPModules_test
+from opacus.utils.packed_sequences import _gen_packed_data
 
 
 def lstm_train_fn(
     model: nn.Module,
-    x: torch.Tensor,
+    x: Union[torch.Tensor, PackedSequence],
     state_init: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
 ):
     model.train()
     criterion = nn.MSELoss()
     logits, (hn, cn) = model(x, state_init)
-    y = torch.zeros_like(logits)
-    loss = criterion(logits, y)
+    if isinstance(logits, PackedSequence):
+        y = torch.zeros_like(logits[0])
+        loss = criterion(logits[0], y)
+    else:
+        y = torch.zeros_like(logits)
+        loss = criterion(logits, y)
     loss.backward()
 
 
@@ -36,6 +42,9 @@ class DPLSTM_test(DPModules_test):
         bias=st.booleans(),
         batch_first=st.booleans(),
         zero_init=st.booleans(),
+        packed_input_flag=st.integers(
+            0, 2
+        ),  # 0 indicates no packed sequence input, 1 indicates packed sequence input in sorted order, 2 indicates packed sequence input in unsorted order
     )
     @settings(deadline=10000)
     def test_lstm(
@@ -49,6 +58,7 @@ class DPLSTM_test(DPModules_test):
         bias: bool,
         batch_first: bool,
         zero_init: bool,
+        packed_input_flag: int,
     ):
         lstm = nn.LSTM(
             emb_size,

--- a/opacus/tests/dp_layers/dp_lstm_test.py
+++ b/opacus/tests/dp_layers/dp_lstm_test.py
@@ -69,11 +69,21 @@ class DPLSTM_test(DPModules_test):
 
         dp_lstm.load_state_dict(lstm.state_dict())
 
-        x = (
-            torch.randn([batch_size, seq_len, emb_size])
-            if batch_first
-            else torch.randn([seq_len, batch_size, emb_size])
-        )
+        if packed_input_flag == 0:
+            x = (
+                torch.randn([batch_size, seq_len, emb_size])
+                if batch_first
+                else torch.randn([seq_len, batch_size, emb_size])
+            )
+        elif packed_input_flag == 1:
+            x = _gen_packed_data(
+                batch_size, seq_len, emb_size, batch_first, sorted_=True
+            )
+        elif packed_input_flag == 2:
+            x = _gen_packed_data(
+                batch_size, seq_len, emb_size, batch_first, sorted_=False
+            )
+
         if zero_init:
             self.compare_forward_outputs(
                 lstm,

--- a/opacus/tests/grad_samples/common.py
+++ b/opacus/tests/grad_samples/common.py
@@ -3,17 +3,15 @@
 
 import io
 import unittest
-from typing import Dict
+from typing import Dict, List, Union
 
 import numpy as np
 import opacus
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.testing import assert_allclose
-
 from torch.nn.utils.rnn import PackedSequence, pad_packed_sequence
-from typing import List, Union
+from torch.testing import assert_allclose
 
 
 def expander(x, factor: int = 2):

--- a/opacus/tests/grad_samples/common.py
+++ b/opacus/tests/grad_samples/common.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 from torch.testing import assert_allclose
 
 from torch.nn.utils.rnn import PackedSequence, pad_packed_sequence
-from typing import List, Optional, Union
+from typing import List, Union
 
 
 def expander(x, factor: int = 2):

--- a/opacus/tests/grad_samples/dp_lstm_test.py
+++ b/opacus/tests/grad_samples/dp_lstm_test.py
@@ -6,9 +6,9 @@ import torch
 import torch.nn as nn
 from hypothesis import given, settings
 from opacus.layers import DPLSTM
+from opacus.utils.packed_sequences import _gen_packed_data
 
 from .common import GradSampleHooks_test
-from opacus.utils.packed_sequences import _gen_packed_data
 
 
 class DPSLTMAdapter(nn.Module):

--- a/opacus/tests/grad_samples/dp_lstm_test.py
+++ b/opacus/tests/grad_samples/dp_lstm_test.py
@@ -10,6 +10,7 @@ from opacus.layers import DPLSTM
 from .common import GradSampleHooks_test
 from opacus.utils.packed_sequences import _gen_packed_data
 
+
 class DPSLTMAdapter(nn.Module):
     """
     Adapter for DPLSTM.
@@ -55,7 +56,12 @@ class LSTM_test(GradSampleHooks_test):
     ):
 
         lstm = DPSLTMAdapter(
-            D, H, num_layers=num_layers, batch_first=batch_first, bias=bias, bidirectional=bidirectional
+            D,
+            H,
+            num_layers=num_layers,
+            batch_first=batch_first,
+            bias=bias,
+            bidirectional=bidirectional,
         )
         if using_packed_sequences:
             x = _gen_packed_data(N, T, D, batch_first, packed_sequences_sorted)

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -164,9 +164,7 @@ class SampleLSTMs():
 
     def init_lstms(self):
         lstm_unidirectional = DPLSTM(input_size=self.input_size, hidden_size=9, num_layers=2, bidirectional=False, batch_first=True)
-        print(len([p for p in lstm_unidirectional.parameters() if p.requires_grad]))
         lstm_bidirectional = DPLSTM(input_size=self.input_size, hidden_size=9, num_layers=2, bidirectional=True, batch_first=True)
-        print(len([p for p in lstm_bidirectional.parameters() if p.requires_grad]))
         self.lstms = [lstm_unidirectional, lstm_bidirectional]
 
     def step(self, data):

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import unittest
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -12,6 +13,8 @@ from opacus.utils.module_inspection import get_layer_type, requires_grad
 from torch.utils.data import DataLoader
 from torchvision import models, transforms
 from torchvision.datasets import FakeData
+from opacus.layers import DPLSTM
+from torch.nn.utils.rnn import PackedSequence, pad_sequence, pack_padded_sequence
 
 
 def get_grad_sample_aggregated(tensor: torch.Tensor, loss_type: str = "mean"):
@@ -30,6 +33,76 @@ def get_grad_sample_aggregated(tensor: torch.Tensor, loss_type: str = "mean"):
         grad_sample_aggregated /= b_sz
 
     return grad_sample_aggregated
+
+
+def _gen_packed_data(
+    minibatch_size: int,
+    max_seq_length: int,
+    input_dim: int,
+    batch_first: bool,
+    sorted_: Optional[bool] = False,
+) -> PackedSequence:
+    """
+    This is used to generate random PackedSequence data, sampled from a normal distribution, for testing DPLSTM.
+
+    Args:
+        minibatch_size : Total number of sequences to generate
+        max_seq_length : The maximum number of timesteps of a sequence
+        input_dim : The embedding dimension of a sequence at any timestep
+        batch_first : If this is true, data is first generated using a padded sequence of dimension (minibatch_size x max_seq_len x input_dim) , else: (max_seq_length x minibatch_size x input_dim)
+        sorted_ : If this is true then the original generated data used to produce the PackedSequence will already be ordered based on sequence lengths, else a random order and the 'sorted_indices'
+                    and 'unsorted_indices' fields will be None.
+
+    Return Value:
+        packed_data : A PackedSequence object with its data sampled from a normal distribution.
+    """
+
+    if batch_first:
+        data = []
+        seq_lengths = []
+        for i in range(minibatch_size):
+            seq_length = torch.randint(1, max_seq_length + 1, (1,)).item()
+            seq_lengths.append(seq_length)
+            data.append(torch.randn(seq_length, input_dim))
+
+        if sorted_:
+            key = lambda x: x.shape[0]
+            data = sorted(data, key=key, reverse=True)
+            seq_lengths = sorted(seq_lengths, reverse=True)
+            packed_data = pack_padded_sequence(
+                pad_sequence(data, batch_first=True),
+                seq_lengths,
+                batch_first=True,
+                enforce_sorted=True,
+            )
+        else:
+            packed_data = pack_padded_sequence(
+                pad_sequence(data, batch_first=True),
+                seq_lengths,
+                batch_first=True,
+                enforce_sorted=False,
+            )
+    else:
+        seq_lengths = [
+            torch.randint(1, max_seq_length + 1, (1,)).item()
+            for i in range(minibatch_size)
+        ]
+        if sorted_:
+            seq_lengths = sorted(seq_lengths, reverse=True)
+        padded_data = torch.zeros((max_seq_length, minibatch_size, input_dim))
+        for i in range(minibatch_size):
+            padded_data[: seq_lengths[i], i, :] = torch.randn(seq_lengths[i], input_dim)
+
+        if sorted_:
+            packed_data = pack_padded_sequence(
+                padded_data, seq_lengths, batch_first=False, enforce_sorted=True
+            )
+        else:
+            packed_data = pack_padded_sequence(
+                padded_data, seq_lengths, batch_first=False, enforce_sorted=False
+            )
+
+    return packed_data
 
 
 class SampleConvNet(nn.Module):
@@ -74,6 +147,58 @@ class SampleConvNet(nn.Module):
     def name(self):
         return "SampleConvNet"
 
+class SampleLSTMs():
+    input_size = 20
+    max_seq_length = 30
+    def __init__(self, model_initializer, **kwargs):
+        self.criterion = nn.MSELoss()
+        self.init_lstms()
+        fn_kwargs = kwargs.copy()
+
+        for idx, lstm in enumerate(self.lstms):
+            if 'state_dict' in kwargs:
+                fn_kwargs['state_dict'] = kwargs['state_dict'][idx]
+
+            model, optimizer = model_initializer(model=lstm, **fn_kwargs)
+            self.lstms[idx] = [model, optimizer]
+
+    def init_lstms(self):
+        lstm_unidirectional = DPLSTM(input_size=self.input_size, hidden_size=9, num_layers=2, bidirectional=False, batch_first=True)
+        print(len([p for p in lstm_unidirectional.parameters() if p.requires_grad]))
+        lstm_bidirectional = DPLSTM(input_size=self.input_size, hidden_size=9, num_layers=2, bidirectional=True, batch_first=True)
+        print(len([p for p in lstm_bidirectional.parameters() if p.requires_grad]))
+        self.lstms = [lstm_unidirectional, lstm_bidirectional]
+
+    def step(self, data):
+        for x in data:
+            for lstm, optimizer in self.lstms:
+                optimizer.zero_grad()
+                output, (hn, cn) = lstm(x)
+                y = torch.zeros_like(output[0])
+                loss = self.criterion(output[0], y)
+                loss.backward()
+                optimizer.step()
+
+    def name(self):
+        return "SampleLSTMs"
+
+    def state_dicts(self):
+        dicts = []
+        for model, _ in self.lstms:
+            dicts.append(model.state_dict())
+        return dicts
+
+    def get_models(self):
+        models = []
+        for i in self.lstms:
+            models.append(i[0])
+        return models
+
+    def get_optimizers(self):
+        optimizers = []
+        for i in self.lstms:
+            optimizers.append(i[1])
+        return optimizers
 
 class PrivacyEngine_test(unittest.TestCase):
     def setUp(self):
@@ -82,22 +207,35 @@ class PrivacyEngine_test(unittest.TestCase):
         self.SAMPLE_RATE = self.BATCH_SIZE / self.DATA_SIZE
         self.LR = 0.5
         self.ALPHAS = [1 + x / 10.0 for x in range(1, 100, 10)]
-        self.criterion = nn.CrossEntropyLoss()
+        self.criterion_cnn = nn.CrossEntropyLoss()
 
-        self.setUp_data()
-        self.original_model, self.original_optimizer = self.setUp_init_model()
-        self.private_model, self.private_optimizer = self.setUp_init_model(
+        self.setUp_data_cnn()
+        self.setUp_data_lstm()
+
+        self.original_model_lstms = SampleLSTMs(self.setUp_init_model)
+        self.private_model_lstms = SampleLSTMs(self.setUp_init_model, 
             private=True,
-            state_dict=self.original_model.state_dict(),
+            state_dict=self.original_model_lstms.state_dicts(),
             noise_multiplier=1.3,
             max_grad_norm=1.0,
         )
 
-        self.original_grads_norms = self.setUp_model_step(
-            self.original_model, self.original_optimizer
+        self.original_model_lstms.step(self.dl_lstm)
+        self.private_model_lstms.step(self.dl_lstm)
+
+        self.original_model_cnn, self.original_optimizer_cnn = self.setUp_init_model()
+        self.private_model_cnn, self.private_optimizer_cnn = self.setUp_init_model(
+            private=True,
+            state_dict=self.original_model_cnn.state_dict(),
+            noise_multiplier=1.3,
+            max_grad_norm=1.0,
         )
-        self.private_grads_norms = self.setUp_model_step(
-            self.private_model, self.private_optimizer
+
+        self.original_grads_norms_cnn = self.setUp_model_step(
+            self.original_model_cnn, self.original_optimizer_cnn
+        )
+        self.private_grads_norms_cnn = self.setUp_model_step(
+            self.private_model_cnn, self.private_optimizer_cnn
         )
         self.privacy_default_params = {
             "noise_multiplier": 1.0,
@@ -105,8 +243,8 @@ class PrivacyEngine_test(unittest.TestCase):
             "secure_rng": False,
         }
 
-    def setUp_data(self):
-        self.ds = FakeData(
+    def setUp_data_cnn(self):
+        self.ds_cnn = FakeData(
             size=self.DATA_SIZE,
             image_size=(1, 35, 35),
             num_classes=10,
@@ -114,7 +252,11 @@ class PrivacyEngine_test(unittest.TestCase):
                 [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
             ),
         )
-        self.dl = DataLoader(self.ds, batch_size=self.BATCH_SIZE)
+        self.dl_cnn = DataLoader(self.ds_cnn, batch_size=self.BATCH_SIZE)
+
+    def setUp_data_lstm(self):
+        ds_lstm = _gen_packed_data(self.DATA_SIZE, SampleLSTMs.max_seq_length, SampleLSTMs.input_size, True)
+        self.dl_lstm = [ds_lstm]
 
     def setUp_init_model(
         self, private=False, state_dict=None, model=None, **privacy_engine_kwargs
@@ -137,12 +279,16 @@ class PrivacyEngine_test(unittest.TestCase):
 
         return model, optimizer
 
-    def setUp_model_step(self, model: nn.Module, optimizer: torch.optim.Optimizer):
+    def setUp_model_step(self, model: nn.Module, optimizer: torch.optim.Optimizer, model_name: str = 'cnn'):
 
-        for x, y in self.dl:
+        if model_name == 'cnn':
+            dl = self.dl_cnn
+            criterion = self.criterion_cnn
+
+        for x, y in dl:
             optimizer.zero_grad()
             logits = model(x)
-            loss = self.criterion(logits, y)
+            loss = criterion(logits, y)
             loss.backward()
             optimizer.step()
 
@@ -192,52 +338,74 @@ class PrivacyEngine_test(unittest.TestCase):
 
     def test_privacy_analysis_alpha_in_alphas(self):
         target_delta = 1e-5
-        eps, alpha = self.private_optimizer.privacy_engine.get_privacy_spent(
+        eps, alpha = self.private_optimizer_cnn.privacy_engine.get_privacy_spent(
             target_delta
         )
         self.assertTrue(alpha in self.ALPHAS)
 
+        for optimizer in self.private_model_lstms.get_optimizers():
+            _, alpha = optimizer.privacy_engine.get_privacy_spent(target_delta)
+            self.assertTrue(alpha in self.ALPHAS)
+
     def test_privacy_analysis_epsilon(self):
         target_delta = 1e-5
-        eps, alpha = self.private_optimizer.privacy_engine.get_privacy_spent(
+        eps, alpha = self.private_optimizer_cnn.privacy_engine.get_privacy_spent(
             target_delta
         )
         self.assertTrue(eps > 0)
+
+        for optimizer in self.private_model_lstms.get_optimizers():
+            eps, _ = optimizer.privacy_engine.get_privacy_spent(target_delta)
+            self.assertTrue(eps > 0)
 
     def test_gradients_change(self):
         """
         Test that gradients are different after one step of SGD
         """
         for layer_grad, private_layer_grad in zip(
-            [p.grad for p in self.original_model.parameters() if p.requires_grad],
-            [p.grad for p in self.private_model.parameters() if p.requires_grad],
+            [p.grad for p in self.original_model_cnn.parameters() if p.requires_grad],
+            [p.grad for p in self.private_model_cnn.parameters() if p.requires_grad],
         ):
             self.assertFalse(torch.allclose(layer_grad, private_layer_grad))
+
+        for model, private_model in zip(self.original_model_lstms.get_models(), self.private_model_lstms.get_models()):
+            for layer_grad, private_layer_grad in zip(
+                [p.grad for p in model.parameters() if p.requires_grad],
+                [p.grad for p in private_model.parameters() if p.requires_grad],
+            ):
+                self.assertFalse(torch.allclose(layer_grad, private_layer_grad))
 
     def test_model_weights_change(self):
         """
         Test that the updated models are different after one step of SGD
         """
         for layer, private_layer in zip(
-            [p for p in self.original_model.parameters() if p.requires_grad],
-            [p for p in self.private_model.parameters() if p.requires_grad],
+            [p for p in self.original_model_cnn.parameters() if p.requires_grad],
+            [p for p in self.private_model_cnn.parameters() if p.requires_grad],
         ):
             self.assertFalse(torch.allclose(layer, private_layer))
+
+        for model, private_model in zip(self.original_model_lstms.get_models(), self.private_model_lstms.get_models()):
+            for layer, private_layer in zip(
+                [p for p in model.parameters() if p.requires_grad],
+                [p for p in private_model.parameters() if p.requires_grad],
+            ):
+                self.assertFalse(torch.allclose(layer, private_layer))
 
     def test_grad_consistency(self):
         model, optimizer = self.setUp_init_model(
             private=True,
-            state_dict=self.original_model.state_dict(),
+            state_dict=self.original_model_cnn.state_dict(),
             noise_multiplier=0,
             max_grad_norm=999,
         )
 
         grad_sample_aggregated = {}
 
-        for x, y in self.dl:
+        for x, y in self.dl_cnn:
             optimizer.zero_grad()
             logits = model(x)
-            loss = self.criterion(logits, y)
+            loss = self.criterion_cnn(logits, y)
             loss.backward()
 
             # collect all per-sample gradients before we take the step
@@ -297,6 +465,35 @@ class PrivacyEngine_test(unittest.TestCase):
                     f"Layer: {layer_name}. Private gradients with noise 0 doesn't match original",
                 )
 
+
+        original_lstms = SampleLSTMs(self.setUp_init_model)
+        private_lstms = SampleLSTMs(self.setUp_init_model, 
+            private=True,
+            state_dict=self.original_model_lstms.state_dicts(),
+            noise_multiplier=0,
+            max_grad_norm=999,
+        )
+
+        for _ in range(3):
+            original_lstms.step(self.dl_lstm)
+            private_lstms.step(self.dl_lstm)
+
+        for original_model, private_model in zip(original_lstms.get_models(), private_lstms.get_models()):
+            for layer_name, private_layer in private_model.named_children():
+                if not requires_grad(private_layer):
+                    continue
+
+                original_layer = getattr(original_model, layer_name)
+
+                for layer, private_layer in zip(
+                    [p.grad for p in original_layer.parameters() if p.requires_grad],
+                    [p.grad for p in private_layer.parameters() if p.requires_grad],
+                ):
+                    self.assertTrue(
+                        torch.allclose(layer, private_layer, atol=10e-4, rtol=10e-2),
+                        f"Layer: {layer_name}. Private gradients with noise 0 doesn't match original",
+                    )
+
     def test_grad_matches_original_per_layer_clipping(self):
         original_model, orignial_optimizer = self.setUp_init_model()
         private_model, private_optimizer = self.setUp_init_model(
@@ -333,7 +530,7 @@ class PrivacyEngine_test(unittest.TestCase):
         """
         model, optimizer = self.setUp_init_model(
             private=True,
-            state_dict=self.original_model.state_dict(),
+            state_dict=self.original_model_cnn.state_dict(),
             noise_multiplier=1.3,
             max_grad_norm=999,
         )
@@ -342,7 +539,7 @@ class PrivacyEngine_test(unittest.TestCase):
 
         model, optimizer = self.setUp_init_model(
             private=True,
-            state_dict=self.original_model.state_dict(),
+            state_dict=self.original_model_cnn.state_dict(),
             noise_multiplier=1.3,
             max_grad_norm=999,
         )
@@ -364,7 +561,7 @@ class PrivacyEngine_test(unittest.TestCase):
             max_grad_norm=1,
         )
         with self.assertRaises(IncompatibleModuleException):
-            privacy_engine.attach(self.private_optimizer)
+            privacy_engine.attach(self.private_optimizer_cnn)
 
     def test_deterministic_run(self):
         """
@@ -441,7 +638,7 @@ class PrivacyEngine_test(unittest.TestCase):
         """
         model, optimizer = self.setUp_init_model(
             private=True,
-            state_dict=self.original_model.state_dict(),
+            state_dict=self.original_model_cnn.state_dict(),
             noise_multiplier=1.3,
             max_grad_norm=999,
             secure_rng=True,
@@ -451,7 +648,7 @@ class PrivacyEngine_test(unittest.TestCase):
 
         model, optimizer = self.setUp_init_model(
             private=True,
-            state_dict=self.original_model.state_dict(),
+            state_dict=self.original_model_cnn.state_dict(),
             noise_multiplier=1.3,
             max_grad_norm=999,
             secure_rng=True,

--- a/opacus/utils/packed_sequences.py
+++ b/opacus/utils/packed_sequences.py
@@ -1,8 +1,7 @@
 from typing import Optional
 
 import torch
-from torch.nn.utils.rnn import (PackedSequence, pack_padded_sequence,
-                                pad_sequence)
+from torch.nn.utils.rnn import PackedSequence, pack_padded_sequence, pad_sequence
 
 
 def _gen_packed_data(

--- a/opacus/utils/packed_sequences.py
+++ b/opacus/utils/packed_sequences.py
@@ -1,0 +1,72 @@
+from torch.nn.utils.rnn import pad_sequence, pack_padded_sequence, PackedSequence
+import torch
+from typing import List, Optional, Tuple, Union
+
+
+def _gen_packed_data(
+    minibatch_size: int,
+    max_seq_length: int,
+    input_dim: int,
+    batch_first: bool,
+    sorted_: Optional[bool] = False,
+) -> PackedSequence:
+    """
+    This is used to generate random PackedSequence data, sampled from a normal distribution, for testing DPLSTM.
+
+    Args:
+        minibatch_size : Total number of sequences to generate
+        max_seq_length : The maximum number of timesteps of a sequence
+        input_dim : The embedding dimension of a sequence at any timestep
+        batch_first : If this is true, data is first generated using a padded sequence of dimension (minibatch_size x max_seq_len x input_dim) , else: (max_seq_length x minibatch_size x input_dim)
+        sorted_ : If this is true then the original generated data used to produce the PackedSequence will already be ordered based on sequence lengths, else a random order and the 'sorted_indices'
+                    and 'unsorted_indices' fields will be None.
+
+    Return Value:
+        packed_data : A PackedSequence object with its data sampled from a normal distribution.
+    """
+
+    if batch_first:
+        data = []
+        seq_lengths = []
+        for _ in range(minibatch_size):
+            seq_length = torch.randint(1, max_seq_length + 1, (1,)).item()
+            seq_lengths.append(seq_length)
+            data.append(torch.randn(seq_length, input_dim))
+
+        if sorted_:
+            data = sorted(data, key=lambda x: x.shape[0], reverse=True)
+            seq_lengths = sorted(seq_lengths, reverse=True)
+            packed_data = pack_padded_sequence(
+                pad_sequence(data, batch_first=True),
+                seq_lengths,
+                batch_first=True,
+                enforce_sorted=True,
+            )
+        else:
+            packed_data = pack_padded_sequence(
+                pad_sequence(data, batch_first=True),
+                seq_lengths,
+                batch_first=True,
+                enforce_sorted=False,
+            )
+    else:
+        seq_lengths = [
+            torch.randint(1, max_seq_length + 1, (1,)).item()
+            for _ in range(minibatch_size)
+        ]
+        if sorted_:
+            seq_lengths = sorted(seq_lengths, reverse=True)
+        padded_data = torch.zeros((max_seq_length, minibatch_size, input_dim))
+        for i in range(minibatch_size):
+            padded_data[: seq_lengths[i], i, :] = torch.randn(seq_lengths[i], input_dim)
+
+        if sorted_:
+            packed_data = pack_padded_sequence(
+                padded_data, seq_lengths, batch_first=False, enforce_sorted=True
+            )
+        else:
+            packed_data = pack_padded_sequence(
+                padded_data, seq_lengths, batch_first=False, enforce_sorted=False
+            )
+
+    return packed_data

--- a/opacus/utils/packed_sequences.py
+++ b/opacus/utils/packed_sequences.py
@@ -1,7 +1,8 @@
 from typing import Optional
 
 import torch
-from torch.nn.utils.rnn import PackedSequence, pack_padded_sequence, pad_sequence
+from torch.nn.utils.rnn import (PackedSequence, pack_padded_sequence,
+                                pad_sequence)
 
 
 def _gen_packed_data(

--- a/opacus/utils/packed_sequences.py
+++ b/opacus/utils/packed_sequences.py
@@ -1,6 +1,6 @@
 from torch.nn.utils.rnn import pad_sequence, pack_padded_sequence, PackedSequence
 import torch
-from typing import List, Optional, Tuple, Union
+from typing import Optional
 
 
 def _gen_packed_data(

--- a/opacus/utils/packed_sequences.py
+++ b/opacus/utils/packed_sequences.py
@@ -1,6 +1,8 @@
-from torch.nn.utils.rnn import pad_sequence, pack_padded_sequence, PackedSequence
-import torch
 from typing import Optional
+
+import torch
+from torch.nn.utils.rnn import (PackedSequence, pack_padded_sequence,
+                                pad_sequence)
 
 
 def _gen_packed_data(


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue
This is a pull request in response to the [issue](https://github.com/pytorch/opacus/issues/103) for adding support for PackedSequence in DPLSTM. An example usage is shown below:
```python
from opacus.layers import DPLSTM
import torch 

seq_batch = [torch.tensor([[1, 1],
                           [2, 2],
                           [3, 3],
                           [4, 4],
                           [5, 5]]),
             torch.tensor([[10, 10],
                           [20, 20]])]

seq_lens = [5, 2]

padded_seq_batch = torch.nn.utils.rnn.pad_sequence(seq_batch, batch_first=True)
packed_seq_batch = torch.nn.utils.rnn.pack_padded_sequence(padded_seq_batch, lengths=seq_lens, batch_first=True)

dp_lstm = DPLSTM(input_size=2, hidden_size=3, batch_first=True)
output, (hn, cn) = dp_lstm(packed_seq_batch.float())

```
<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
This has been tested analogously to the way that DPLSTM (without PackedSequence) has been tested. The outputs and parameters of DPLSTM (with PackedSequence) and LSTM (with PackedSequence) have been compared in the tests.
## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
