### PR TITLE
Read version in setup.py

### DIFF
--- a/opacus/__init__.py
+++ b/opacus/__init__.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-from .version import __version__
-
 from . import utils
 from .per_sample_gradient_clip import PerSampleGradientClipper
 from .privacy_engine import PrivacyEngine
+from .version import __version__
+
 
 __all__ = ["PrivacyEngine", "PerSampleGradientClipper", "utils", "__version__"]

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,20 @@ import os
 import sys
 
 from setuptools import find_packages, setup
-from version import __version__
+
 
 # 3.6.8 is the final Windows binary release for 3.6.x
 # Google Colab also requires 3.6.9
 REQUIRED_MAJOR = 3
 REQUIRED_MINOR = 6
 REQUIRED_MICRO = 8
+
+
+version = {}
+with open("opacus/version.py") as fp:
+    exec(fp.read(), version)
+
+__version__ = version["__version__"]
 
 # Check for python version
 if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR, REQUIRED_MICRO):


### PR DESCRIPTION
Summary: This fixes setup.py to read version correctly following a known Python recipe for this: https://packaging.python.org/guides/single-sourcing-package-version/

Differential Revision: D26032585

