### PR TITLE
Rewrote the grad_sample tests to use Hypothesis

### DIFF
--- a/opacus/tests/grad_samples/conv1d_test.py
+++ b/opacus/tests/grad_samples/conv1d_test.py
@@ -16,14 +16,14 @@ shrinker = lambda x: x // 2
 
 class Conv1d_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32]),
-        C=st.sampled_from([3, 4, 12, 24]),
-        W=st.sampled_from([11, 10]),
+        N=st.integers(16,32),
+        C=st.integers(3, 24),
+        W=st.integers(10, 11),
         out_channels_mapper=st.sampled_from([expander, shrinker]),
-        kernel_size=st.sampled_from([2, 3]),
-        stride=st.sampled_from([1, 2]),
-        padding=st.sampled_from([0, 2]),
-        groups=st.sampled_from([1, 2, 3, 12]),
+        kernel_size=st.integers(2, 3),
+        stride=st.integers(1, 2),
+        padding=st.integers(0, 2),
+        groups=st.integers(1, 12),
     )
     @settings(deadline=10000)
     def test_conv1d(

--- a/opacus/tests/grad_samples/conv2d_test.py
+++ b/opacus/tests/grad_samples/conv2d_test.py
@@ -16,15 +16,15 @@ shrinker = lambda x: x // 2
 
 class Conv2d_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32, 48]),
-        C=st.sampled_from([3, 16, 32]),
-        H=st.sampled_from([9, 10, 16, 24]),
-        W=st.sampled_from([9, 10, 16, 24]),
+        N=st.integers(32, 48),
+        C=st.integers(3, 32),
+        H=st.integers(9, 24),
+        W=st.integers(9, 24),
         out_channels_mapper=st.sampled_from([expander, shrinker]),
-        kernel_size=st.sampled_from([2, 3]),
-        stride=st.sampled_from([1, 2]),
+        kernel_size=st.integers(2, 3),
+        stride=st.integers(1, 2),
         padding=st.sampled_from([0, 2]),
-        groups=st.sampled_from([1, 2, 4, 16]),
+        groups=st.integers(1, 16),
     )
     @settings(deadline=10000)
     def test_conv2d(

--- a/opacus/tests/grad_samples/conv2d_test.py
+++ b/opacus/tests/grad_samples/conv2d_test.py
@@ -1,122 +1,58 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from typing import Optional, Tuple, Callable
+
+import hypothesis.strategies as st
 import torch
 import torch.nn as nn
+from hypothesis import given, settings
 
 from .common import GradSampleHooks_test
 
+expander = lambda x: 2 * x
+shrinker = lambda x: x // 2
+
 
 class Conv2d_test(GradSampleHooks_test):
-    def test_square_image_kernel2(self):
-        N, C, H, W = 32, 3, 10, 10
+    @given(
+        N=st.sampled_from([32, 48]),
+        C=st.sampled_from([3, 16, 32]),
+        H=st.sampled_from([9, 10, 16, 24]),
+        W=st.sampled_from([9, 10, 16, 24]),
+        out_channels_mapper=st.sampled_from([expander, shrinker]),
+        kernel_size=st.sampled_from([2, 3]),
+        stride=st.sampled_from([1, 2]),
+        padding=st.sampled_from([0, 2]),
+        groups=st.sampled_from([1, 2, 4, 16]),
+    )
+    @settings(deadline=10000)
+    def test_conv2d(
+        self,
+        N: int,
+        C: int,
+        H: int,
+        W: int,
+        out_channels_mapper: Callable[[int], int],
+        kernel_size: int,
+        stride: int,
+        padding: int,
+        groups: int,
+    ):
+
+        out_channels = out_channels_mapper(C)
+        if (
+            C % groups != 0 or out_channels % groups != 0
+        ):  # since in_channels and out_channels must be divisible by groups
+            return
+
         x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=2)
+        conv = nn.Conv2d(
+            in_channels=C,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            groups=groups,
+        )
         self.run_test(x, conv, batch_first=True)
-
-    def test_landscape_image_kernel2(self):
-        N, C, H, W = 32, 3, 9, 16
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=2)
-        self.run_test(x, conv, batch_first=True)
-
-    def test_portrait_image_kernel2(self):
-        N, C, H, W = 32, 3, 16, 9
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=2)
-        self.run_test(x, conv, batch_first=True)
-
-    def test_square_image_kernel3(self):
-        N, C, H, W = 32, 3, 10, 10
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=3)
-        self.run_test(x, conv, batch_first=True)
-
-    def test_landscape_image_kernel3(self):
-        N, C, H, W = 32, 3, 9, 16
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=3)
-        self.run_test(x, conv, batch_first=True)
-
-    def test_portrait_image_kernel3(self):
-        N, C, H, W = 32, 3, 16, 9
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=3)
-        self.run_test(x, conv, batch_first=True)
-
-    def test_square_image_stride_2(self):
-        N, C, H, W = 32, 3, 10, 10
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=2, stride=2)
-        self.run_test(x, conv, batch_first=True)
-
-    def test_landscape_image_stride_2(self):
-        N, C, H, W = 32, 3, 9, 16
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=2, stride=2)
-        self.run_test(x, conv, batch_first=True)
-
-    def test_portrait_image_stride_2(self):
-        N, C, H, W = 32, 3, 16, 9
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=2, stride=2)
-        self.run_test(x, conv, batch_first=True)
-
-    def test_square_image_pad_2(self):
-        N, C, H, W = 32, 3, 10, 10
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=2, padding=2)
-        self.run_test(x, conv, batch_first=True)
-
-    def test_landscape_image_pad_2(self):
-        N, C, H, W = 32, 3, 9, 16
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=2, padding=2)
-        self.run_test(x, conv, batch_first=True)
-
-    def test_portrait_image_pad_2(self):
-        N, C, H, W = 32, 3, 16, 9
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, 2 * C, kernel_size=2, padding=2)
-        self.run_test(x, conv, batch_first=True)
-
-    """
-    These generally show up in upper layers. At this point, C is just generic "channels"
-    and it generally shrinks rather than expanding
-    """
-
-    def test_4d_input_2_groups_expanding(self):
-        N, C, H, W = 48, 16, 24, 24
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, C * 2, kernel_size=3, stride=1, groups=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-4)
-
-    def test_4d_input_2_groups_shrinking(self):
-        N, C, H, W = 48, 32, 24, 24
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, C // 2, kernel_size=3, stride=1, groups=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-4)
-
-    def test_4d_input_4_groups_expanding(self):
-        N, C, H, W = 48, 16, 24, 24
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, C * 2, kernel_size=3, stride=1, groups=4)
-        self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-4)
-
-    def test_4d_input_4_groups_shrinking(self):
-        N, C, H, W = 48, 32, 24, 24
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, C // 2, kernel_size=3, stride=1, groups=4)
-        self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-4)
-
-    def test_4d_input_16_groups_expanding(self):
-        N, C, H, W = 48, 16, 24, 24
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, C * 2, kernel_size=3, stride=1, groups=16)
-        self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-4)
-
-    def test_4d_input_16_groups_shrinking(self):
-        N, C, H, W = 48, 32, 24, 24
-        x = torch.randn([N, C, H, W])
-        conv = nn.Conv2d(C, C // 2, kernel_size=3, stride=1, groups=16)
-        self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-4)

--- a/opacus/tests/grad_samples/conv3d_test.py
+++ b/opacus/tests/grad_samples/conv3d_test.py
@@ -16,11 +16,11 @@ shrinker = lambda x: x // 2
 
 class Conv3d_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32]),
-        C=st.sampled_from([3]),
-        D=st.sampled_from([4, 5, 10]),
-        H=st.sampled_from([9, 10, 16]),
-        W=st.sampled_from([9, 10, 16]),
+        N=st.integers(16,32),
+        C=st.integers(2, 5),
+        D=st.integers(4, 10),
+        H=st.integers(9, 16),
+        W=st.integers(9, 16),
         out_channels_mapper=st.sampled_from([expander, shrinker]),
         kernel_size=st.sampled_from([2, 3, (1, 2, 3)]),
         stride=st.sampled_from([1, 2, (1, 2, 3)]),
@@ -52,15 +52,15 @@ class Conv3d_test(GradSampleHooks_test):
         self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
 
     @given(
-        N=st.sampled_from([4]),
-        C=st.sampled_from([16, 32]),
-        D=st.sampled_from([12]),
-        H=st.sampled_from([12]),
-        W=st.sampled_from([12]),
+        N=st.integers(16,32),
+        C=st.integers(2,5),
+        D=st.integers(8, 12),
+        H=st.integers(4,7),
+        W=st.integers(8,12),
         out_channels_mapper=st.sampled_from([expander, shrinker]),
         kernel_size=st.sampled_from([3]),
         stride=st.sampled_from([1]),
-        groups=st.sampled_from([2, 4, 16]),
+        groups=st.integers(2, 16),
     )
     @settings(deadline=10000)
     def test_4d_inputs(

--- a/opacus/tests/grad_samples/conv3d_test.py
+++ b/opacus/tests/grad_samples/conv3d_test.py
@@ -1,176 +1,93 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from typing import Optional, Tuple, Callable, Union
+
+import hypothesis.strategies as st
 import torch
 import torch.nn as nn
+from hypothesis import given, settings
 
 from .common import GradSampleHooks_test
 
+expander = lambda x: 2 * x
+shrinker = lambda x: x // 2
+
 
 class Conv3d_test(GradSampleHooks_test):
-    def test_square_image_kernel2(self):
-        N, C, D, H, W = 32, 1, 10, 10, 10
+    @given(
+        N=st.sampled_from([32]),
+        C=st.sampled_from([3]),
+        D=st.sampled_from([4, 5, 10]),
+        H=st.sampled_from([9, 10, 16]),
+        W=st.sampled_from([9, 10, 16]),
+        out_channels_mapper=st.sampled_from([expander, shrinker]),
+        kernel_size=st.sampled_from([2, 3, (1, 2, 3)]),
+        stride=st.sampled_from([1, 2, (1, 2, 3)]),
+        padding=st.sampled_from([0, 2, (1, 2, 3)]),
+    )
+    @settings(deadline=10000)
+    def test_images(
+        self,
+        N: int,
+        C: int,
+        D: int,
+        H: int,
+        W: int,
+        out_channels_mapper: Callable[[int], int],
+        kernel_size: Union[int, Tuple[int]],
+        stride: Union[int, Tuple[int]],
+        padding: Union[int, Tuple[int]],
+    ):
+
+        out_channels = out_channels_mapper(C)
         x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, C, kernel_size=2)
+        conv = nn.Conv3d(
+            in_channels=C,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+        )
         self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
 
-    def test_landscape_image_kernel2(self):
-        N, C, D, H, W = 32, 3, 4, 9, 16
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
+    @given(
+        N=st.sampled_from([4]),
+        C=st.sampled_from([16, 32]),
+        D=st.sampled_from([12]),
+        H=st.sampled_from([12]),
+        W=st.sampled_from([12]),
+        out_channels_mapper=st.sampled_from([expander, shrinker]),
+        kernel_size=st.sampled_from([3]),
+        stride=st.sampled_from([1]),
+        groups=st.sampled_from([2, 4, 16]),
+    )
+    @settings(deadline=10000)
+    def test_4d_inputs(
+        self,
+        N: int,
+        C: int,
+        D: int,
+        H: int,
+        W: int,
+        out_channels_mapper: Callable[[int], int],
+        kernel_size: int,
+        stride: int,
+        groups: int,
+    ):
 
-    def test_portrait_image_kernel2(self):
-        N, C, D, H, W = 32, 3, 4, 16, 9
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
+        out_channels = out_channels_mapper(C)
+        if (
+            C % groups != 0 or out_channels % groups != 0
+        ):  # since in_channels and out_channels must be divisible by groups
+            return
 
-    def test_square_image_kernel3(self):
-        N, C, D, H, W = 32, 3, 10, 10, 10
         x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=3)
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_landscape_image_kernel3(self):
-        N, C, D, H, W = 32, 3, 5, 9, 16
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=3)
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_portrait_image_kernel3(self):
-        N, C, D, H, W = 32, 3, 5, 16, 9
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=3)
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_square_image_stride_2(self):
-        N, C, D, H, W = 32, 3, 10, 10, 10
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, stride=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_landscape_image_stride_2(self):
-        N, C, D, H, W = 32, 3, 5, 9, 16
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, stride=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_portrait_image_stride_2(self):
-        N, C, D, H, W = 32, 3, 5, 16, 9
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, stride=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_square_image_pad_2(self):
-        N, C, D, H, W = 32, 3, 10, 10, 10
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, padding=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_landscape_image_pad_2(self):
-        N, C, D, H, W = 32, 3, 5, 9, 16
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, padding=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_portrait_image_pad_2(self):
-        N, C, D, H, W = 32, 3, 5, 16, 9
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, padding=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_square_image_variable_pad(self):
-        N, C, D, H, W = 32, 3, 10, 10, 10
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, padding=(1, 2, 3))
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_landscape_image_variable_pad(self):
-        N, C, D, H, W = 32, 3, 5, 9, 16
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, padding=(1, 2, 3))
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_portrait_image_variable_pad(self):
-        N, C, D, H, W = 32, 3, 5, 16, 9
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, padding=(1, 2, 3))
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_square_image_variable_kernel(self):
-        N, C, D, H, W = 32, 3, 10, 10, 10
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=(1, 2, 3))
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_landscape_image_variable_kernel(self):
-        N, C, D, H, W = 32, 3, 4, 9, 16
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=(1, 2, 3))
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_portrait_image_variable_kernel(self):
-        N, C, D, H, W = 32, 3, 4, 16, 9
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=(1, 2, 3))
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_square_image_variable_stride(self):
-        N, C, D, H, W = 32, 3, 10, 10, 10
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, stride=(1, 2, 3))
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_landscape_image_variable_stride(self):
-        N, C, D, H, W = 32, 3, 5, 9, 16
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, stride=(1, 2, 3))
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    def test_portrait_image_variable_stride(self):
-        N, C, D, H, W = 32, 3, 5, 16, 9
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, 2 * C, kernel_size=2, stride=(1, 2, 3))
-        self.run_test(x, conv, batch_first=True, atol=10e-6, rtol=10e-3)
-
-    """
-    These generally show up in upper layers. At this point, C is just generic "channels"
-    and it generally shrinks rather than expanding
-    """
-
-    def test_4d_input_2_groups_expanding(self):
-        N, C, D, H, W = 4, 16, 12, 12, 12
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, C * 2, kernel_size=3, stride=1, groups=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-3)
-
-    def test_4d_input_2_groups_shrinking(self):
-        N, C, D, H, W = 4, 32, 12, 12, 12
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, C // 2, kernel_size=3, stride=1, groups=2)
-        self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-3)
-
-    def test_4d_input_4_groups_expanding(self):
-        N, C, D, H, W = 4, 16, 12, 12, 12
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, C * 2, kernel_size=3, stride=1, groups=4)
-        self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-3)
-
-    def test_4d_input_4_groups_shrinking(self):
-        N, C, D, H, W = 4, 32, 12, 12, 12
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, C // 2, kernel_size=3, stride=1, groups=4)
-        self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-3)
-
-    def test_4d_input_16_groups_expanding(self):
-        N, C, D, H, W = 4, 16, 12, 12, 12
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, C * 2, kernel_size=3, stride=1, groups=16)
-        self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-3)
-
-    def test_4d_input_16_groups_shrinking(self):
-        N, C, D, H, W = 4, 32, 12, 12, 12
-        x = torch.randn([N, C, D, H, W])
-        conv = nn.Conv3d(C, C // 2, kernel_size=3, stride=1, groups=16)
+        conv = nn.Conv3d(
+            in_channels=C,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            groups=groups,
+        )
         self.run_test(x, conv, batch_first=True, atol=10e-5, rtol=10e-3)

--- a/opacus/tests/grad_samples/dp_lstm_test.py
+++ b/opacus/tests/grad_samples/dp_lstm_test.py
@@ -31,10 +31,10 @@ class DPSLTMAdapter(nn.Module):
 
 class LSTM_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32, 1]),
-        T=st.sampled_from([20]),
-        D=st.sampled_from([8]),
-        H=st.sampled_from([16]),
+        N=st.integers(1, 32),
+        T=st.integers(15,20),
+        D=st.integers(4, 7),
+        H=st.integers(10, 16),
         num_layers=st.sampled_from([1, 2]),
         bias=st.booleans(),
         batch_first=st.booleans(),

--- a/opacus/tests/grad_samples/dp_multihead_attention_test.py
+++ b/opacus/tests/grad_samples/dp_multihead_attention_test.py
@@ -36,9 +36,9 @@ class DPMultiheadAttentionAdapter(nn.Module):
 
 class MultiHeadAttention_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32]),
-        T=st.sampled_from([20]),
-        D=st.sampled_from([8]),
+        N=st.integers(16,32),
+        T=st.integers(16,20),
+        D=st.sampled_from([4]),
         P=st.sampled_from([1, 2]),
         bias=st.booleans(),
         add_bias_kv=st.booleans(),

--- a/opacus/tests/grad_samples/embedding_test.py
+++ b/opacus/tests/grad_samples/embedding_test.py
@@ -4,38 +4,45 @@
 import torch
 import torch.nn as nn
 
+from typing import Optional, Tuple, Callable, Union
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
 from .common import GradSampleHooks_test
 
 
 class Embedding_test(GradSampleHooks_test):
-    def test_1d_input(self):
-        V, D = 128, 17
-        T = 12
+    @given(
+        N=st.sampled_from([32]),
+        T=st.sampled_from([12]),
+        Q=st.sampled_from([4]),
+        R=st.sampled_from([2]),
+        V=st.sampled_from([128]),
+        D=st.sampled_from([17]),
+        dim=st.sampled_from([1, 2, 3, 4]),
+    )
+    @settings(deadline=10000)
+    def test_input_across_dims(
+        self,
+        N: int,
+        T: int,
+        Q: int,
+        R: int,
+        V: int,
+        D: int,
+        dim: int,
+    ):
+
+        if dim == 1:
+            size = [T]
+        elif dim == 2:
+            size = [N, T]
+        elif dim == 3:
+            size = [N, T, Q]
+        elif dim == 4:
+            size = [N, T, Q, R]
 
         emb = nn.Embedding(V, D)
-        x = torch.randint(low=0, high=V - 1, size=[T])
-        self.run_test(x, emb, batch_first=True)
-
-    def test_2d_input(self):
-        V, D = 128, 17
-        N, T = 32, 12
-
-        emb = nn.Embedding(V, D)
-        x = torch.randint(low=0, high=V - 1, size=[N, T])
-        self.run_test(x, emb, batch_first=True)
-
-    def test_3d_input(self):
-        V, D = 128, 17
-        N, T, Q = 32, 12, 4
-
-        emb = nn.Embedding(V, D)
-        x = torch.randint(low=0, high=V - 1, size=[N, T, Q])
-        self.run_test(x, emb, batch_first=True)
-
-    def test_4d_input(self):
-        V, D = 128, 17
-        N, T, Q, R = 32, 12, 4, 2
-
-        emb = nn.Embedding(V, D)
-        x = torch.randint(low=0, high=V - 1, size=[N, T, Q, R])
+        x = torch.randint(low=0, high=V - 1, size=size)
         self.run_test(x, emb, batch_first=True)

--- a/opacus/tests/grad_samples/embedding_test.py
+++ b/opacus/tests/grad_samples/embedding_test.py
@@ -14,13 +14,13 @@ from .common import GradSampleHooks_test
 
 class Embedding_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32]),
-        T=st.sampled_from([12]),
-        Q=st.sampled_from([4]),
-        R=st.sampled_from([2]),
-        V=st.sampled_from([128]),
-        D=st.sampled_from([17]),
-        dim=st.sampled_from([1, 2, 3, 4]),
+        N=st.integers(20,32),
+        T=st.integers(5,12),
+        Q=st.integers(1,4),
+        R=st.integers(1,2),
+        V=st.integers(2,32),
+        D=st.integers(10,17),
+        dim=st.integers(1, 4),
     )
     @settings(deadline=10000)
     def test_input_across_dims(

--- a/opacus/tests/grad_samples/group_norm_test.py
+++ b/opacus/tests/grad_samples/group_norm_test.py
@@ -18,10 +18,10 @@ class GroupNorm_test(GradSampleHooks_test):
     compute a gradient. There is no grad_sample from this module otherwise.
     """
     @given(
-        N=st.sampled_from([32]),
-        C=st.sampled_from([16]),
-        H=st.sampled_from([8]),
-        W=st.sampled_from([10]),
+        N=st.integers(20, 32),
+        C=st.integers(1,8),
+        H=st.integers(5,10),
+        W=st.integers(4,8),
         num_groups=st.sampled_from([1, 4, "C"]),
     )
     @settings(deadline=10000)
@@ -37,6 +37,9 @@ class GroupNorm_test(GradSampleHooks_test):
         if num_groups == "C":
             num_groups = C
 
+        if C%num_groups != 0:
+            return
+            
         x = torch.randn([N, C, H, W])
         norm = nn.GroupNorm(num_groups=num_groups, num_channels=C, affine=True)
         self.run_test(x, norm, batch_first=True)

--- a/opacus/tests/grad_samples/group_norm_test.py
+++ b/opacus/tests/grad_samples/group_norm_test.py
@@ -4,29 +4,35 @@
 import torch
 import torch.nn as nn
 
+from typing import Optional, Tuple, Callable, Union
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
 from .common import GradSampleHooks_test
 
 
 class GroupNorm_test(GradSampleHooks_test):
-    """
-    We only test the case with ``affine=True`` here, because it is the only case that will actually
-    compute a gradient. There is no grad_sample from this module otherwise.
-    """
+    @given(
+        N=st.sampled_from([32]),
+        C=st.sampled_from([16]),
+        H=st.sampled_from([8]),
+        W=st.sampled_from([10]),
+        num_groups=st.sampled_from([1, 4, "C"]),
+    )
+    @settings(deadline=10000)
+    def test_3d_input_groups(
+        self,
+        N: int,
+        C: int,
+        H: int,
+        W: int,
+        num_groups: Union[int, str],
+    ):
 
-    def test_3d_input_one_group_affine(self):
-        N, C, H, W = 32, 16, 8, 10
-        x = torch.randn([N, C, H, W])
-        norm = nn.GroupNorm(num_groups=1, num_channels=C, affine=True)
-        self.run_test(x, norm, batch_first=True)
+        if num_groups == "C":
+            num_groups = C
 
-    def test_3d_input_four_groups_affine(self):
-        N, C, H, W = 32, 16, 8, 10
         x = torch.randn([N, C, H, W])
-        norm = nn.GroupNorm(num_groups=4, num_channels=C, affine=True)
-        self.run_test(x, norm, batch_first=True)
-
-    def test_3d_input_C_groups_affine(self):
-        N, C, H, W = 32, 16, 8, 10
-        x = torch.randn([N, C, H, W])
-        norm = nn.GroupNorm(num_groups=C, num_channels=C, affine=True)
+        norm = nn.GroupNorm(num_groups=num_groups, num_channels=C, affine=True)
         self.run_test(x, norm, batch_first=True)

--- a/opacus/tests/grad_samples/group_norm_test.py
+++ b/opacus/tests/grad_samples/group_norm_test.py
@@ -13,6 +13,10 @@ from .common import GradSampleHooks_test
 
 
 class GroupNorm_test(GradSampleHooks_test):
+    """
+    We only test the case with ``affine=True`` here, because it is the only case that will actually
+    compute a gradient. There is no grad_sample from this module otherwise.
+    """
     @given(
         N=st.sampled_from([32]),
         C=st.sampled_from([16]),

--- a/opacus/tests/grad_samples/instance_norm1d_test.py
+++ b/opacus/tests/grad_samples/instance_norm1d_test.py
@@ -14,9 +14,9 @@ from .common import GradSampleHooks_test
 
 class InstanceNorm1d_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32]),
-        C=st.sampled_from([3]),
-        W=st.sampled_from([10]),
+        N=st.integers(20, 32),
+        C=st.integers(1,3),
+        W=st.integers(5,10),
     )
     @settings(deadline=10000)
     def test_3d_input(

--- a/opacus/tests/grad_samples/instance_norm1d_test.py
+++ b/opacus/tests/grad_samples/instance_norm1d_test.py
@@ -4,12 +4,28 @@
 import torch
 import torch.nn as nn
 
+from typing import Optional, Tuple, Callable, Union
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
 from .common import GradSampleHooks_test
 
 
 class InstanceNorm1d_test(GradSampleHooks_test):
-    def test_3d_input(self):
-        N, C, W = 32, 3, 10
+    @given(
+        N=st.sampled_from([32]),
+        C=st.sampled_from([3]),
+        W=st.sampled_from([10]),
+    )
+    @settings(deadline=10000)
+    def test_3d_input(
+        self,
+        N: int,
+        C: int,
+        W: int,
+    ):
+
         x = torch.randn([N, C, W])
         norm = nn.InstanceNorm1d(num_features=C, affine=True, track_running_stats=False)
         self.run_test(x, norm, batch_first=True)

--- a/opacus/tests/grad_samples/instance_norm2d_test.py
+++ b/opacus/tests/grad_samples/instance_norm2d_test.py
@@ -14,10 +14,10 @@ from .common import GradSampleHooks_test
 
 class InstanceNorm2d_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32]),
-        C=st.sampled_from([3]),
-        W=st.sampled_from([10]),
-        H=st.sampled_from([8]),
+        N=st.integers(20, 32),
+        C=st.integers(1,3),
+        W=st.integers(5,10),
+        H=st.integers(4,8),
     )
     @settings(deadline=10000)
     def test_4d_input(

--- a/opacus/tests/grad_samples/instance_norm2d_test.py
+++ b/opacus/tests/grad_samples/instance_norm2d_test.py
@@ -4,12 +4,30 @@
 import torch
 import torch.nn as nn
 
+from typing import Optional, Tuple, Callable, Union
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
 from .common import GradSampleHooks_test
 
 
 class InstanceNorm2d_test(GradSampleHooks_test):
-    def test_4d_input(self):
-        N, C, H, W = 32, 3, 8, 10
+    @given(
+        N=st.sampled_from([32]),
+        C=st.sampled_from([3]),
+        W=st.sampled_from([10]),
+        H=st.sampled_from([8]),
+    )
+    @settings(deadline=10000)
+    def test_4d_input(
+        self,
+        N: int,
+        C: int,
+        W: int,
+        H: int,
+    ):
+
         x = torch.randn([N, C, H, W])
         norm = nn.InstanceNorm2d(num_features=C, affine=True, track_running_stats=False)
         self.run_test(x, norm, batch_first=True)

--- a/opacus/tests/grad_samples/instance_norm3d_test.py
+++ b/opacus/tests/grad_samples/instance_norm3d_test.py
@@ -14,11 +14,11 @@ from .common import GradSampleHooks_test
 
 class InstanceNorm3d_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32]),
-        C=st.sampled_from([3]),
-        W=st.sampled_from([10]),
-        H=st.sampled_from([8]),
-        Z=st.sampled_from([4]),
+        N=st.integers(20, 32),
+        C=st.integers(1,3),
+        W=st.integers(5,10),
+        H=st.integers(4,8),
+        Z=st.integers(1,4),
     )
     @settings(deadline=10000)
     def test_5d_input(

--- a/opacus/tests/grad_samples/instance_norm3d_test.py
+++ b/opacus/tests/grad_samples/instance_norm3d_test.py
@@ -4,12 +4,31 @@
 import torch
 import torch.nn as nn
 
+from typing import Optional, Tuple, Callable, Union
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
 from .common import GradSampleHooks_test
 
 
 class InstanceNorm3d_test(GradSampleHooks_test):
-    def test_5d_input(self):
-        N, C, Z, H, W = 32, 3, 4, 8, 10
+    @given(
+        N=st.sampled_from([32]),
+        C=st.sampled_from([3]),
+        W=st.sampled_from([10]),
+        H=st.sampled_from([8]),
+        Z=st.sampled_from([4]),
+    )
+    @settings(deadline=10000)
+    def test_5d_input(
+        self,
+        N: int,
+        C: int,
+        W: int,
+        H: int,
+        Z: int,
+    ):
         x = torch.randn([N, C, Z, H, W])
         norm = nn.InstanceNorm3d(num_features=C, affine=True, track_running_stats=False)
         self.run_test(x, norm, batch_first=True)

--- a/opacus/tests/grad_samples/layer_norm_test.py
+++ b/opacus/tests/grad_samples/layer_norm_test.py
@@ -14,10 +14,10 @@ from .common import GradSampleHooks_test
 
 class LayerNorm_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32]),
-        Z=st.sampled_from([4]),
-        H=st.sampled_from([3]),
-        W=st.sampled_from([10]),
+        N=st.integers(16, 32),
+        Z=st.integers(1,4),
+        H=st.integers(1,3),
+        W=st.integers(5,10),
         input_dim=st.integers(2, 4),
         norm_dim=st.integers(1, 3),
     )

--- a/opacus/tests/grad_samples/layer_norm_test.py
+++ b/opacus/tests/grad_samples/layer_norm_test.py
@@ -1,46 +1,58 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-
 import torch
 import torch.nn as nn
+
+from typing import Optional, Tuple, Callable, Union
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
 
 from .common import GradSampleHooks_test
 
 
 class LayerNorm_test(GradSampleHooks_test):
-    def test_2d_input_1d_norm(self):
-        N, W = 32, 17
-        norm = nn.LayerNorm(W, elementwise_affine=True)
-        x = torch.randn([N, W])
-        self.run_test(x, norm, batch_first=True)
+    @given(
+        N=st.sampled_from([32]),
+        Z=st.sampled_from([4]),
+        H=st.sampled_from([3]),
+        W=st.sampled_from([10]),
+        input_dim=st.integers(2, 4),
+        norm_dim=st.integers(1, 3),
+    )
+    @settings(deadline=10000)
+    def test_input_norm(
+        self,
+        N: int,
+        Z: int,
+        W: int,
+        H: int,
+        input_dim: int,
+        norm_dim: int,
+    ):
 
-    def test_3d_input_1d_norm(self):
-        N, Z, W = 32, 4, 10
-        norm = nn.LayerNorm(W, elementwise_affine=True)
-        x = torch.randn([N, Z, W])
-        self.run_test(x, norm, batch_first=True)
+        if norm_dim >= input_dim:
+            return
+        if norm_dim == 1:
+            normalized_shape = W
+            if input_dim == 2:
+                x_shape = [N, W]
+            if input_dim == 3:
+                x_shape = [N, Z, W]
+            if input_dim == 4:
+                x_shape = [N, Z, H, W]
+        elif norm_dim == 2:
+            if input_dim == 3:
+                normalized_shape = [Z, W]
+                x_shape = [N, Z, W]
+            if input_dim == 4:
+                normalized_shape = [H, W]
+                x_shape = [N, Z, H, W]
+        elif norm_dim == 3:
+            normalized_shape = [Z, H, W]
+            x_shape = [N, Z, H, W]
 
-    def test_3d_input_2d_norm(self):
-        N, Z, W = 32, 4, 10
-        norm = nn.LayerNorm([Z, W], elementwise_affine=True)
-        x = torch.randn([N, Z, W])
-        self.run_test(x, norm, batch_first=True)
-
-    def test_4d_input_1d_norm(self):
-        N, C, H, W = 32, 4, 3, 10
-        norm = nn.LayerNorm(W, elementwise_affine=True)
-        x = torch.randn([N, C, H, W])
-        self.run_test(x, norm, batch_first=True)
-
-    def test_4d_input_2d_norm(self):
-        N, C, H, W = 32, 4, 3, 10
-        norm = nn.LayerNorm([H, W], elementwise_affine=True)
-        x = torch.randn([N, C, H, W])
-        self.run_test(x, norm, batch_first=True)
-
-    def test_4d_input_3d_norm(self):
-        N, C, H, W = 32, 4, 3, 10
-        norm = nn.LayerNorm([C, H, W], elementwise_affine=True)
-        x = torch.randn([N, C, H, W])
+        norm = nn.LayerNorm(normalized_shape, elementwise_affine=True)
+        x = torch.randn(x_shape)
         self.run_test(x, norm, batch_first=True)

--- a/opacus/tests/grad_samples/linear_test.py
+++ b/opacus/tests/grad_samples/linear_test.py
@@ -14,10 +14,10 @@ from .common import GradSampleHooks_test
 
 class Linear_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32]),
-        Z=st.sampled_from([4]),
-        H=st.sampled_from([3]),
-        W=st.sampled_from([10, 17]),
+        N=st.integers(16,32),
+        Z=st.integers(1,4),
+        H=st.integers(1,3),
+        W=st.integers(10, 17),
         input_dim=st.integers(2, 4),
         bias=st.booleans(),
     )

--- a/opacus/tests/grad_samples/linear_test.py
+++ b/opacus/tests/grad_samples/linear_test.py
@@ -4,42 +4,41 @@
 import torch
 import torch.nn as nn
 
+from typing import Optional, Tuple, Callable, Union
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
 from .common import GradSampleHooks_test
 
 
 class Linear_test(GradSampleHooks_test):
-    def test_2d_input_bias(self):
-        N, W = 32, 17
-        linear = nn.Linear(W, W + 2, bias=True)
-        x = torch.randn([N, W])
-        self.run_test(x, linear, batch_first=True)
+    @given(
+        N=st.sampled_from([32]),
+        Z=st.sampled_from([4]),
+        H=st.sampled_from([3]),
+        W=st.sampled_from([10, 17]),
+        input_dim=st.integers(2, 4),
+        bias=st.booleans(),
+    )
+    @settings(deadline=10000)
+    def test_input_bias(
+        self,
+        N: int,
+        Z: int,
+        W: int,
+        H: int,
+        input_dim: int,
+        bias: bool,
+    ):
 
-    def test_3d_input_bias(self):
-        N, Z, W = 32, 4, 10
-        linear = nn.Linear(W, W + 2, bias=True)
-        x = torch.randn([N, Z, W])
-        self.run_test(x, linear, batch_first=True)
+        if input_dim == 2:
+            x_shape = [N, W]
+        if input_dim == 3:
+            x_shape = [N, Z, W]
+        if input_dim == 4:
+            x_shape = [N, Z, H, W]
 
-    def test_4d_input_bias(self):
-        N, Z, Q, W = 32, 4, 3, 10
-        linear = nn.Linear(W, W + 2, bias=True)
-        x = torch.randn([N, Z, Q, W])
-        self.run_test(x, linear, batch_first=True)
-
-    def test_2d_input_nobias(self):
-        N, W = 32, 17
-        linear = nn.Linear(W, W + 2, bias=False)
-        x = torch.randn([N, W])
-        self.run_test(x, linear, batch_first=True)
-
-    def test_3d_input_nobias(self):
-        N, Z, W = 32, 4, 10
-        linear = nn.Linear(W, W + 2, bias=False)
-        x = torch.randn([N, Z, W])
-        self.run_test(x, linear, batch_first=True)
-
-    def test_4d_input_nobias(self):
-        N, Z, Q, W = 32, 4, 3, 10
-        linear = nn.Linear(W, W + 2, bias=False)
-        x = torch.randn([N, Z, Q, W])
+        linear = nn.Linear(W, W + 2, bias=bias)
+        x = torch.randn(x_shape)
         self.run_test(x, linear, batch_first=True)

--- a/opacus/tests/grad_samples/sequence_bias_test.py
+++ b/opacus/tests/grad_samples/sequence_bias_test.py
@@ -2,14 +2,30 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import torch
-from opacus.layers import SequenceBias
 
+from typing import Optional, Tuple, Callable, Union
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+from opacus.layers import SequenceBias
 from .common import GradSampleHooks_test
 
 
 class SequenceBias_test(GradSampleHooks_test):
-    def test_batch_second(self):
-        N, T, D = 32, 20, 8
+    @given(
+        N=st.sampled_from([32]),
+        T=st.sampled_from([20]),
+        D=st.sampled_from([8]),
+    )
+    @settings(deadline=10000)
+    def test_batch_second(
+        self,
+        N: int,
+        T: int,
+        D: int,
+    ):
+
         seqbias = SequenceBias(D)
         x = torch.randn([T, N, D])
         self.run_test(x, seqbias, batch_first=False)

--- a/opacus/tests/grad_samples/sequence_bias_test.py
+++ b/opacus/tests/grad_samples/sequence_bias_test.py
@@ -14,9 +14,9 @@ from .common import GradSampleHooks_test
 
 class SequenceBias_test(GradSampleHooks_test):
     @given(
-        N=st.sampled_from([32]),
-        T=st.sampled_from([20]),
-        D=st.sampled_from([8]),
+        N=st.integers(16,32),
+        T=st.integers(10,20),
+        D=st.integers(4,8),
     )
     @settings(deadline=10000)
     def test_batch_second(


### PR DESCRIPTION
This PR addresses the [issue](https://github.com/pytorch/opacus/issues/122) where it was requested to migrate the Grad Sample tests in the directory ```opacus/tests/grad_samples``` to using hypothesis in order to make it much easier to write new and extend the current test cases. The test configuration space of the added code is at least as large (larger in most cases) as in the old testing code. I can push another commit with this PR to add grad sample test cases for PackedSequence usage in the DPLSTM class once the PackedSequence [functionalities](https://github.com/pytorch/opacus/pull/116) are merged.