### PR TITLE
Disable failing DPMultiheadAttention test

### DIFF
--- a/opacus/tests/dp_layers/dp_multihead_attention_test.py
+++ b/opacus/tests/dp_layers/dp_multihead_attention_test.py
@@ -4,6 +4,7 @@
 from typing import Optional
 
 import hypothesis.strategies as st
+import pytest
 import torch
 import torch.nn as nn
 from hypothesis import given, settings
@@ -38,6 +39,9 @@ class DPMultiheadAttention_test(DPModules_test):
         vdim=st.integers(2, 8) | st.none(),
     )
     @settings(deadline=10000)
+    @pytest.mark.skip(
+        "Failing due to a known problem. Should be enabled after issue #123 is fixed"
+    )
     def test_attn(
         self,
         batch_size: int,


### PR DESCRIPTION
Summary:
## Background
In D25318869 (https://github.com/pytorch/opacus/commit/46a81f99c22cdd40ef20636b7d53963286ba356a) (PR #120) Davide introduced more tests for `dp_layers` package. One of those tests was failing, uncovering a real issue we need to fix.
The underlying problem itself is not high-pri and so it was deemed to be a good first task for the new contributors. Davide then opened an issue on github (https://github.com/pytorch/opacus/issues/123) with a detailed guide for anyone who wants to help. So far there's been no takers, and we wait.

## Issue
Given that the issue is not high-pri and we're aware of it, I don't think we should be using unit tests as a task tracker.
We shouldn't treat red CircleCI as a norm, as it could potentially mask real issues.

## Solution
This diff disables the test in question from running on CircleCI.
I'll comment on the github issue to ask future author of the fix to re-enable the test after the issue is fixed.

Reviewed By: karthikprasad

Differential Revision: D26277444

