### PR TITLE
Return Python types in Privacy Engine

### DIFF
--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -230,7 +230,10 @@ class PrivacyEngine:
         if target_delta is None:
             target_delta = self.target_delta
         rdp = self.get_renyi_divergence() * self.steps
-        return privacy_analysis.get_privacy_spent(self.alphas, rdp, target_delta)
+        eps, best_alpha = privacy_analysis.get_privacy_spent(
+            self.alphas, rdp, target_delta
+        )
+        return float(eps), float(best_alpha)
 
     def zero_grad(self):
         """


### PR DESCRIPTION
Summary: The `get_privacy_spent()` method in the Privacy Engine returns Numpy types. Returning basic Python types is best practice, and it help with integrating Opacus with PySift.

Differential Revision: D26556155

