### PR TITLE
Enforce kwargs to Privacy Engine

### DIFF
--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -230,7 +230,10 @@ class PrivacyEngine:
         if target_delta is None:
             target_delta = self.target_delta
         rdp = self.get_renyi_divergence() * self.steps
-        return privacy_analysis.get_privacy_spent(self.alphas, rdp, target_delta)
+        eps, best_alpha = privacy_analysis.get_privacy_spent(
+            self.alphas, rdp, target_delta
+        )
+        return float(eps), float(best_alpha)
 
     def zero_grad(self):
         """

--- a/opacus/tests/docstring_examples_test.py
+++ b/opacus/tests/docstring_examples_test.py
@@ -70,9 +70,8 @@ class DocstringExamplesTest(unittest.TestCase):
         optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
         privacy_engine = PrivacyEngine(
             model,
-            batch_size,
-            sample_size,
-            alphas=range(2, 32),
+            batch_size=batch_size,
+            sample_size=sample_size,
             noise_multiplier=1.3,
             max_grad_norm=1.0,
         )
@@ -87,9 +86,8 @@ class DocstringExamplesTest(unittest.TestCase):
         model = torch.nn.Linear(16, 32)  # An example model. Default device is CPU
         privacy_engine = PrivacyEngine(
             model,
-            batch_size,
-            sample_size,
-            alphas=range(5, 64),
+            batch_size=batch_size,
+            sample_size=sample_size,
             noise_multiplier=0.8,
             max_grad_norm=0.5,
         )
@@ -117,9 +115,8 @@ class DocstringExamplesTest(unittest.TestCase):
 
         privacy_engine = PrivacyEngine(
             model,
-            batch_size,
-            sample_size,
-            alphas=range(5, 64),
+            batch_size=batch_size,
+            sample_size=sample_size,
             noise_multiplier=0.8,
             max_grad_norm=0.5,
         )


### PR DESCRIPTION
Summary: This breaking change enforces PrivacyEngine to be constructed with kwargs and is made to ease landing #128

Differential Revision: D26560799

