### PR TITLE
UniformSampler length + tweak CharLSTM example

### DIFF
--- a/examples/char-lstm-classification.py
+++ b/examples/char-lstm-classification.py
@@ -285,6 +285,8 @@ def padded_collate(batch, padding_idx=0):
 
 
 def train(model, criterion, optimizer, train_loader, epoch, device="cuda:0"):
+    model.train()
+
     accs = []
     losses = []
     for x, y in tqdm(train_loader):
@@ -319,6 +321,8 @@ def train(model, criterion, optimizer, train_loader, epoch, device="cuda:0"):
 
 
 def test(model, test_loader, privacy_engine, device="cuda:0"):
+    model.eval()
+
     accs = []
     with torch.no_grad():
         for x, y in tqdm(test_loader):

--- a/opacus/utils/uniform_sampler.py
+++ b/opacus/utils/uniform_sampler.py
@@ -34,7 +34,7 @@ class UniformWithReplacementSampler(Sampler):
             )
 
     def __len__(self):
-        return self.num_samples
+        return int(1 / self.sample_rate)
 
     def __iter__(self):
         num_batches = int(1 / self.sample_rate)


### PR DESCRIPTION
Summary:
Tweaking CharLSTM example with two changes:

1) Iteration progress bar is wrong. It goes:
```
0%|▏                              | 20/16059 [00:14<3:07:14,  1.43it/s]
```
And finishes at 20/16059.

The reason is `UniformWithReplacementSampler` is actually a batch sampler, so it's length  should represent number of batches, not the number of samples.

This change makes `__len__` consistent with `__iter__`

2) Added calls to `model.eval()` and `model.train()` in corresponding methods. At the moment we don't switch to `eval` mode while testing, thus accumulating unnecessary gradients

Differential Revision: D26846668

