### PR TITLE
Update requirements.txt for examples

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy>=1.15
 torch>=1.3
-torchvision>=0.4
+torchvision>=0.9
 tqdm>=4.40
 scipy>=1.2
 pytest
+requests


### PR DESCRIPTION
Summary:
Update requirements.txt to address ongoing issues with our integrations tests.

There are two:
a. `ModuleNotFoundError: No module named 'requests'` ([CircleCI](https://app.circleci.com/pipelines/github/pytorch/opacus/632/workflows/d7e18eab-b988-4d77-89e0-1632f8f6677e/jobs/3019/steps))

The problem here is that `torchvision` uses `requests` to handle redirects, but doesn't list it as a dependency. We need it for MNIST example

b. `urllib.error.HTTPError: HTTP Error 403: Forbidden` for MNIST download.
It surfaces once you've fixed the issue with `requests`. ([CircleCI](https://app.circleci.com/pipelines/github/pytorch/opacus/619/workflows/4e5c8506-9512-40e8-a1d0-8a77642940a4/jobs/2945))

See [Issue #1938](https://github.com/pytorch/vision/issues/1938) on torchvision
torchvision fixed this in the latest release 0.9 ([#3499](https://github.com/pytorch/vision/pull/3499)).

Differential Revision: D26885337

