### PR TITLE
Switch MNIST integration test to latest torchvision

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,9 @@ commands:
             mkdir mnist
             mkdir mnist/data
             mkdir mnist/test-reports
+            sudo apt-get update
+            sudo apt-get install libjpeg-turbo8-dev
+            sudo "$(which python)" -m pip install --upgrade git+git://github.com/pytorch/vision.git@814c4f08bc9296a314ecb9e216648e0d059a3edc
             echo "Using $(python -V) ($(which python))"
             echo "Using $(pip -V) ($(which pip))"
             python examples/mnist.py --lr 0.25 --sigma 0.7 -c 1.5 --sample-rate 0.004 --epochs 1 --data-root mnist/data --n-runs 1 --device <<parameters.device>>


### PR DESCRIPTION
Summary:
yann.lecun.com is having availability issues, which leads to our integration tests failing.

torchvision addressed the issue recently - the change haven't yet made it to the release, but it works if you install from sources.

I suggest we temporary add github installation into CircleCI config for now, and then move to the latest torchvision as soon as it's released

Reviewed By: karthikprasad

Differential Revision: D27208798

