### PR TITLE
PR 162 Conversion from RDP to (eps, delta)-DP by a new Formula

### DIFF
--- a/opacus/privacy_analysis.py
+++ b/opacus/privacy_analysis.py
@@ -272,15 +272,17 @@ def get_privacy_spent(
 ) -> Tuple[float, float]:
     r"""Computes epsilon given a list of Renyi Differential Privacy (RDP) values at
     multiple RDP orders and target ``delta``.
-
+    The computation of epslion, i.e. conversion from RDP to (eps, delta)-DP,
+    is based on the theorem presented in the following work:
+    Borja Balle et al. "Hypothesis testing interpretations and Renyi differential privacy."
+    International Conference on Artificial Intelligence and Statistics. PMLR, 2020.
+    Particullary, Theorem 21 in the arXiv version https://arxiv.org/abs/1905.09982.
     Args:
         orders: An array (or a scalar) of orders (alphas).
         rdp: A list (or a scalar) of RDP guarantees.
         delta: The target delta.
-
     Returns:
         Pair of epsilon and optimal order alpha.
-
     Raises:
         ValueError
             If the lengths of ``orders`` and ``rdp`` are not equal.
@@ -295,7 +297,11 @@ def get_privacy_spent(
             f"\trdp_vec = {rdp_vec}\n"
         )
 
-    eps = rdp_vec - math.log(delta) / (orders_vec - 1)
+    eps = (
+        rdp_vec
+        - (np.log(delta) + np.log(orders_vec)) / (orders_vec - 1)
+        + np.log((orders_vec - 1) / orders_vec)
+    )
 
     # special case when there is no privacy
     if np.isnan(eps).all():


### PR DESCRIPTION
Summary:
We propose to use the state-of-the-art formula for computing eps in opacus/privacy_analysis.py method get_privacy_spent().

related to issue: #157

Details:

Currently, the computed epsilon from RDP to (epsilon, delta)-DP is the Line 298 in opacus/privacy_analysis.py that is eps = rdp_vec - math.log(delta) / (orders_vec - 1).

The current line is based on Proposition 3 in the main RDP paper (Mironov2017):
Ilya Mironov. "Renyi differential privacy." IEEE 30th Computer Security Foundations Symposium (CSF). 2017.

However, in the following paper (Balle2020) authors provide a better conversion from RDP to DP:
Borja Balle et al. "Hypothesis testing interpretations and Renyi differential privacy." International Conference on Artificial Intelligence and Statistics. PMLR, 2020. Particullary, Theorem 21 in the arXiv version https://arxiv.org/abs/1905.09982.

As this new analysis provides us a better bound (i.e. smaller epsilons), it should be more useful to the users of Opacus.

In this pull request:

I have replaced Line 298 with the formula proposed in Balle2020 Theorem 21 as explained above.

I have added information about this paper to the description of the method get_privacy_spent().

As the only difference of this new formula, compared to the previous one, is that it gives us smaller epsilons, and the method's functionality does not change, I believe existing unit tests should be sufficient for this change.

https://github.com/pytorch/opacus/pull/162

Merging this PR the correct way

Differential Revision: D27825676

