### PR TITLE
Do not store activations within torch.no_grad

### DIFF
--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -165,7 +165,11 @@ class GradSampleModule(nn.Module):
         forward_input: List[torch.Tensor],
         _forward_output: torch.Tensor,
     ):
-        if not requires_grad(module) or not module.training:
+        if (
+            not requires_grad(module)
+            or not module.training
+            or not torch.is_grad_enabled()
+        ):
             return
 
         if not self.hooks_enabled:


### PR DESCRIPTION
Summary: Check that grad is enabled before storing activations

Reviewed By: karthikprasad, ffuuugor

Differential Revision: D28797697

