### PR TITLE
Downgrade to torch==1.8.1 for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
     steps:
       - run:
           name: "Install dependencies via pip"
-          command: ./scripts/install_via_pip.sh << parameters.args >>
+          command: ./scripts/install_via_pip.sh -v 1.8.1 << parameters.args >>
 
   lint_flake8:
     description: "Lint with flake8"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,4 @@
+torch==1.8.1
 torchvision>=0.9.1
 tqdm>=4.40
 requests>=2.25.1


### PR DESCRIPTION
Summary:
~~Pip install on dev_requirements started to time out recently.
One possible reason is dependency resolver, which has almost no constraints and takes too long to find satisfying versions.~~

```
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime.
```

~~Let's see if reducing the search space helps.~~

~~NB: all package versions are what was the latest available at the end of 2020~~

Ok, I was wrong

The actual problem was pytorch 1.9 release. 
We have no problem supporting it, but latest `torchcsprng` has a pegged dependency on 1.8.

So what happens is
1) we install regular `requirements.txt` with `torch==1.9.0`
2) we try to install `torchcsprng`, which requires 1.8, can't and fail.

The strange timeout behaviour is down to the [new pip dependency resolver](https://pyfound.blogspot.com/2020/11/pip-20-3-new-resolver.html) - instead of flagging the conflict it tries to traverse the graph and find the non-conflicting combination. Clearly, it's impossible, but brave and tenacious dependency resolver timeouts, instead of telling what's wrong

(fun fact: debugging this involved running `pip install --use-deprecated=legacy-resolver`, which is not a great sign for a new feature)

PS:
I thought that the correct way to address this was to install `requirements.txt` and `dev_requirements.txt` at the same time, so the pip would figure out himself that the only option is 1.8. Unfortunately, it doesn't - it installs 1.9 and then fails. Not so smart after all

PS2:
Non-dev dependency stays as `torch>=1.3`, so people will be able to use opacus with torch 1.9

Differential Revision: D29265512

