### PR TITLE
Improve nn.Linear grad sampler memory consumption

### DIFF
--- a/opacus/grad_sample/linear.py
+++ b/opacus/grad_sample/linear.py
@@ -20,10 +20,8 @@ def compute_linear_grad_sample(
         B: Backpropagations
         batch_dim: Batch dimension position
     """
-    gs = torch.einsum("n...i,n...j->n...ij", B, A)
-    create_or_extend_grad_sample(
-        layer.weight, torch.einsum("n...ij->nij", gs), batch_dim
-    )
+    gs = torch.einsum("n...i,n...j->nij", B, A)
+    create_or_extend_grad_sample(layer.weight, gs, batch_dim)
     if layer.bias is not None:
 
         create_or_extend_grad_sample(


### PR DESCRIPTION
Summary:
**Issue**: when running our [text classifier tutorial](https://opacus.ai/tutorials/building_text_classifier) you're very likely to run into OOM.

**Sort of reason**: Poisson batch sampling. We've calibrated batch size (=8) to just fit into 16GB cuda memory. With random sampling we get batches with 10-12 samples and that pushes us over the limit

**Real reason**: Our nn.Linear is incredibly inefficient on 3+ - dimensional inputs.
By splitting the computation into two steps:
```
gs = torch.einsum("n...i,n...j->n...ij", B, A)
torch.einsum("n...ij->nij", gs)
```
we explicitly store intermediate result, which preserves all the extra dimensions, that are not needed for actual grad sample computation.

To put some real numbers on this, let's consider one of the layers from the tutorial. We have `nn.Linear(3072, 768)` and `seq_len=128`:
```
# A.shape = (8, 128, 3072)
# B.shape = (8, 128, 768)

gs = torch.einsum("n...i,n...j->n...ij", B, A)
# shape = (8, 128, 768, 3072), size = 9GB

torch.einsum("n...ij->nij", gs)
# shape = (8, 768, 3072), size = 72MB
```

Here, the memory we actually need (72MB) is 128(=`seq_len`) times smaller than the peak memory.

**Solution**
As it turns out, `einsum` stays very efficient if we do the same operation in one step:
```
gs = torch.einsum("n...i,n...j->nij", B, A)
```

Here's the peak memory graph for the tutorial case:
{F628256051}

For more clarity, here's the same graph, but with `seq_len=4` so the difference is not that drastic - you can clearly see that the peak memory is improved by the factor of `seq_len` (in this case 4)

{F628256115}

Differential Revision: D29416182

