### PR TITLE
DDP support for faster distributed training

### DIFF
--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -108,7 +108,7 @@ class GradSampleModule(nn.Module):
         Special function to enable DDP support on top of a GradSampleModule
         """
 
-        self.ddp_hook_activated = True
+        self.ddp_hooks = True
 
         # We store the number of layers for the per-layer clipping
         self.n_params = 0
@@ -125,7 +125,7 @@ class GradSampleModule(nn.Module):
         """
         self.disable_hooks()
 
-        if self.ddp_hook_activated:
+        if self.ddp_hooks:
             pass
             # TODO: remove DDP hooks
 
@@ -316,7 +316,6 @@ class GradSampleModule(nn.Module):
         del p.grad_sample
 
         # Average (or sum) across the batch
-        # TODO: add support for Poisson batch sampling
         res = engine.clipper._scale_summed_grad(p.summed_grad, batch_size)
 
         del p.summed_grad

--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -286,7 +286,7 @@ class GradSampleModule(nn.Module):
 
     def ddp_backward_callback(self, engine, p, grad):
         """
-        This hook operates like PrivacyEngine.step(), but on a single layer:
+        This hook operates like ``PrivacyEngine.step()``, but on a single layer:
         1. clip_and_accumulate
         2. get the clip_values with clipper.pre_step()
         3. add the noise

--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -333,12 +333,11 @@ class GradSampleModule(nn.Module):
         #         f"max_grad_norm: {engine.max_grad_norm} \nclipping_tresh: {clipping_thresh}\nclip_value: {clip_value}"
         #     )
 
-        noise = _generate_noise_ddp(engine, clip_value, res)
-        if engine.loss_reduction == "mean":
-            noise /= batch_size
-
         # Only one GPU adds noise
         if engine.rank == 0:
+            noise = _generate_noise_ddp(engine, clip_value, res)
+            if engine.loss_reduction == "mean":
+                noise /= batch_size
             res += noise
 
         return res

--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -8,6 +8,8 @@ import torch.nn as nn
 from opacus.layers.dp_lstm import DPLSTM, LSTMLinear
 from opacus.utils.module_inspection import requires_grad
 
+from opacus.utils.tensor_utils import calc_sample_norms
+
 
 class UnsupportedModuleError(ValueError):
     pass
@@ -99,6 +101,42 @@ class GradSampleModule(nn.Module):
                     )
                 )
         self.enable_hooks()
+
+    def add_ddp_hook(
+        self, engine, loss_reduction: str = "mean", batch_first: bool = True
+    ) -> None:
+        """
+        Special function to enable DDP support on top of a GradSampleModule
+        """
+
+        # self.n_params = len(
+        #     [n for n, p in self.module.named_parameters() if p.requires_grad]
+        # )
+
+        # We store the number of layers for the per-layer clipping
+        self.n_params = 0
+        self.ddp_hook_activated = True
+
+        # TODO: should we use self._module.parameters() instead?
+
+        # for module in self.trainable_modules():
+        #     if type(module) in self.GRAD_SAMPLERS:
+        #         self.n_params += 1
+        #         self.autograd_grad_sample_hooks.append(
+        #             module.register_hook(
+        #                 partial(
+        #                     self.ddp_backward_callback,
+        #                     engine,
+        #                     module,
+        #                 )
+        #             )
+        #         )
+
+        # We iterate over the parameters and not the submodules
+        for p in self.parameters():
+            if p.requires_grad:
+                self.n_params += 1
+                p.register_hook(partial(self.ddp_backward_callback, engine, p))
 
     def remove_hooks(self) -> None:
         """
@@ -259,6 +297,94 @@ class GradSampleModule(nn.Module):
     def is_supported(cls, module: nn.Module) -> bool:
         """Check if this module is supported"""
         return type(module) in cls.GRAD_SAMPLERS or type(module) is DPLSTM
+
+    def ddp_backward_callback(self, engine, p, grad):
+        """
+        This hook operates like PrivacyEngine.step(), but on a single layer:
+        1. clip_and_accumulate
+        2. get the clip_values with clipper.pre_step()
+        3. add the noise
+        """
+
+        # Get the norm of the gradient for each sample for this layer
+        all_norms = calc_sample_norms(
+            named_params=((None, p.grad_sample),),
+            flat=False,
+        )
+
+        # Get the constant clipping factor for a single layer
+        clipping_factor = engine.clipper.norm_clipper.calc_clipping_factors(all_norms)
+        assert len(clipping_factor) == 1
+        clip_factor = clipping_factor[0]
+        batch_size = p.grad_sample.shape[0]
+
+        # Do the clipping
+        summed_grad = engine.clipper._weighted_sum(clip_factor, p.grad_sample)
+
+        # accumulate the summed gradient for this mini-batch
+        if hasattr(p, "summed_grad"):
+            p.summed_grad += summed_grad
+        else:
+            p.summed_grad = summed_grad
+
+        del p.grad_sample
+
+        # Average (or sum) across the batch
+        # TODO: add support for Poisson batch sampling
+        res = engine.clipper._scale_summed_grad(p.summed_grad, batch_size)
+
+        del p.summed_grad
+
+        # NOTE: `self.clipper.pre_step()` returns a tensor with n=n_params clip_values
+        # where each clip_value is the L2 norm of `threshs`:
+        #   `max_norm = threshs.new_full((n,), threshs.norm(2))`
+        # With per layer clipping, `threshs` is a tensor with n flat_values
+        assert len(engine.clipper.norm_clipper.thresholds) == 1
+        clipping_thresh = engine.clipper.norm_clipper.thresholds[0]
+        clip_value = (self.n_params ** 0.5) * clipping_thresh
+        # if engine.rank == 0:
+        #     print(
+        #         f"max_grad_norm: {engine.max_grad_norm} \nclipping_tresh: {clipping_thresh}\nclip_value: {clip_value}"
+        #     )
+
+        noise = _generate_noise_ddp(engine, clip_value, res)
+        if engine.loss_reduction == "mean":
+            noise /= batch_size
+
+        # Only one GPU adds noise
+        if engine.rank == 0:
+            res += noise
+
+        return res
+
+
+def _generate_noise_ddp(
+    engine, max_grad_norm: float, reference: nn.parameter.Parameter
+) -> torch.Tensor:
+    r"""
+    Generates a tensor of Gaussian noise of the same shape as ``reference``.
+
+    The generated tensor has zero mean and standard deviation
+    sigma = ``noise_multiplier x max_grad_norm ``
+
+    Args:
+        max_grad_norm : The maximum norm of the per-sample gradients.
+        reference : The reference, based on which the dimention of the
+            noise tensor will be determined
+
+    Returns:
+        the generated noise with noise zero and standard
+        deviation of ``noise_multiplier x max_grad_norm ``
+    """
+    if engine.noise_multiplier > 0 and max_grad_norm > 0:
+        return torch.normal(
+            0,
+            engine.noise_multiplier * max_grad_norm,
+            reference.shape,
+            device=engine.device,
+            generator=engine.random_number_generator,
+        )
+    return torch.zeros(reference.shape, device=engine.device)
 
 
 def _get_batch_size(

--- a/opacus/layers/dp_ddp.py
+++ b/opacus/layers/dp_ddp.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 def average_gradients(model):
     world_size = torch.distributed.get_world_size()
     for param in model.parameters():
+        if not param.requires_grad: continue
         torch.distributed.all_reduce(param.grad, op=torch.distributed.ReduceOp.SUM)
         param.grad /= world_size
 
@@ -15,6 +16,7 @@ def average_gradients(model):
 class DifferentiallyPrivateDistributedDataParallel(nn.Module):
     def __init__(self, model):
         super().__init__()
+        # TODO: We should synchronize the model at the beginning
         self.module = model
 
     def forward(self, *args, **kwargs):

--- a/opacus/layers/dp_ddp.py
+++ b/opacus/layers/dp_ddp.py
@@ -17,7 +17,13 @@ def average_gradients(model):
 class DifferentiallyPrivateDistributedDataParallel(nn.Module):
     def __init__(self, model):
         super().__init__()
-        # TODO: We should synchronize the model at the beginning
+
+        # Synchronize the model
+        params = list(model.parameters())
+        with torch.no_grad():
+            for p in params:
+                torch.distributed.broadcast(p.data, 0)
+
         self.module = model
 
     def forward(self, *args, **kwargs):

--- a/opacus/layers/dp_ddp.py
+++ b/opacus/layers/dp_ddp.py
@@ -8,7 +8,8 @@ import torch.nn as nn
 def average_gradients(model):
     world_size = torch.distributed.get_world_size()
     for param in model.parameters():
-        if not param.requires_grad: continue
+        if not param.requires_grad:
+            continue
         torch.distributed.all_reduce(param.grad, op=torch.distributed.ReduceOp.SUM)
         param.grad /= world_size
 

--- a/opacus/per_sample_gradient_clip.py
+++ b/opacus/per_sample_gradient_clip.py
@@ -34,8 +34,9 @@ Notes:
 from typing import Callable, Iterator, Optional, Tuple
 
 import torch
-from opacus.grad_sample import GradSampleModule
 from torch import nn
+
+from opacus.grad_sample import GradSampleModule
 
 from .utils.clipping import NormClipper
 from .utils.tensor_utils import calc_sample_norms

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -500,16 +500,14 @@ class PrivacyEngine:
 
         params = (p for p in self.module.parameters() if p.requires_grad)
         for p, clip_value in zip(params, clip_values):
-            noise = self._generate_noise(clip_value, p)
-            if self.loss_reduction == "mean":
-                noise /= batch_size
-
-            # TODO: Why do we need to generate noise on every GPU if only rank0 will use it?
             if self.rank == 0:
                 # Noise only gets added on first worker
                 # This is easy to reason about for loss_reduction=sum
                 # For loss_reduction=mean, noise will get further divided by
                 # world_size as gradients are averaged.
+                noise = self._generate_noise(clip_value, p)
+                if self.loss_reduction == "mean":
+                    noise /= batch_size
                 p.grad += noise
 
             # For poisson, we are not supposed to know the batch size

--- a/opacus/tests/ddp_hook_test.py
+++ b/opacus/tests/ddp_hook_test.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+import os
+import sys
+import unittest
+import time
+import random
+from unittest.main import main
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+import torch.optim as optim
+from opacus import PrivacyEngine
+from opacus.layers import DifferentiallyPrivateDistributedDataParallel as DPDDP
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+
+PRIVACY_ALPHAS = [1 + x / 10.0 for x in range(1, 100)] + list(range(12, 64))
+
+
+def setup_and_get_device(rank, world_size, nonce=0):
+    """
+    Initialize the torch.distributed process group.
+    If you run multiple groups in parallel or if you have zombie processes, you can add a nonce to avoid errors.
+    """
+    device = 0
+    if sys.platform == "win32":
+        # Distributed package only covers collective communications with Gloo
+        # backend and FileStore on Windows platform. Set init_method parameter
+        # in init_process_group to a local file.
+        # Example init_method="file:///f:/libtmp/some_file"
+        init_method = "file:///{your local file path}"
+
+        # initialize the process group
+        dist.init_process_group(
+            "gloo", init_method=init_method, rank=rank, world_size=world_size
+        )
+        device = rank
+    elif os.environ.get("SLURM_NTASKS") is not None:
+        # Running on a Slurm cluster
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(7440 + nonce)
+        local_rank = int(os.environ.get("SLURM_LOCALID"))
+        dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+
+        # The device is the local rank (if you have 2 nodes with 8 GPUs each, you will have two "cuda:0" devices)
+        device = local_rank
+    else:
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "12355"
+
+        os.environ["RANK"] = str(rank)
+        os.environ["WORLD_SIZE"] = str(world_size)
+        dist.init_process_group(
+            init_method="env://",
+            backend="nccl",
+        )
+
+        # Single node experiment
+        device = rank
+    return device
+
+
+def cleanup():
+    dist.destroy_process_group()
+
+
+class ToyModel(nn.Module):
+    def __init__(self):
+        super(ToyModel, self).__init__()
+        self.net1 = nn.Linear(10, 10)
+        self.relu = nn.ReLU()
+        self.net2 = nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.net2(self.relu(self.net1(x)))
+
+
+def demo_basic(rank, world_size, weight, dp, noise_multiplier=0, max_grad_norm=1e8):
+    # We don't want the 2 GPUs to work on the same examples/labels in parallel
+    torch.manual_seed(rank)
+    batch_size = 32
+    withdp = "with" + ("out " if not dp else "")
+    print(f"Running basic DDP {withdp} differential privacy example on rank {rank}.")
+
+    device = setup_and_get_device(rank, world_size)
+
+    # create model and move it to GPU with id rank
+    model = ToyModel().to(device)
+    print(f"Initial weight: {model.net1.weight.data}")
+
+    # Freeze all the parameters except one, to ensure that the noise is the same
+    # (the DDP hook does not browse the layers in the same order as the naive implementation)
+    model.net1.bias.requires_grad = False
+    model.net2.bias.requires_grad = False
+    model.net2.weight.requires_grad = False
+
+    # Synchronize the model
+    params = list(model.parameters())
+    with torch.no_grad():
+        for p in params:
+            dist.broadcast(p.data, 0)
+    # print(f"Weight after synchronization: {model.net1.weight.data}")
+
+    if dp:
+        ddp_model = DPDDP(model)
+        engine = PrivacyEngine(
+            ddp_model,
+            batch_size=batch_size,
+            sample_size=10 * batch_size,
+            alphas=PRIVACY_ALPHAS,
+            noise_multiplier=noise_multiplier,
+            max_grad_norm=max_grad_norm,
+            experimental=True,
+            clip_per_layer=True,
+        )
+        engine.random_number_generator = engine._set_seed(0)
+    else:
+        ddp_model = DDP(model, device_ids=[device])
+
+    loss_fn = nn.MSELoss()
+    optimizer = optim.SGD(ddp_model.parameters(), lr=1)
+    if dp:
+        engine.attach(optimizer)
+
+    # if rank == 0:
+    #     print(model.net1.weight)
+    optimizer.zero_grad()
+    labels = torch.randn(batch_size, 5).to(device)
+
+    outputs = ddp_model(torch.randn(batch_size, 10).to(device))
+    loss_fn(outputs, labels).backward()
+    optimizer.step()
+
+    # if rank == 0:
+    #     print(model.net1.weight)
+
+    weight.copy_(model.net1.weight.data.cpu())
+
+    cleanup()
+
+
+def demo_ddp_hook(rank, world_size, weight, dp, noise_multiplier, max_grad_norm):
+    torch.manual_seed(rank)
+    batch_size = 32
+    withdp = "with" + ("out " if not dp else "")
+    print(f"Running DDP hook {withdp} differential privacy example on rank {rank}.")
+
+    device = setup_and_get_device(rank, world_size, nonce=1)
+
+    # create model and move it to GPU with id rank
+    model = ToyModel().to(device)
+    # print(f"Initial weight: {model.net1.weight.data}")
+
+    model.net1.bias.requires_grad = False
+    model.net2.bias.requires_grad = False
+    model.net2.weight.requires_grad = False
+
+    ddp_model = DDP(model, device_ids=[device])
+    # print(f"Initial weight after DDP wrapping: {ddp_model.module.net1.weight.data}")
+
+    if dp:
+        engine = PrivacyEngine(
+            ddp_model,
+            batch_size=batch_size,
+            sample_size=10 * batch_size,
+            alphas=PRIVACY_ALPHAS,
+            noise_multiplier=noise_multiplier,
+            max_grad_norm=max_grad_norm,
+            experimental=True,
+            clip_per_layer=True,
+        )
+        engine.random_number_generator = engine._set_seed(0)
+
+    loss_fn = nn.MSELoss()
+    optimizer = optim.SGD(ddp_model.parameters(), lr=1)
+    if dp:
+        engine.attach(optimizer)
+
+    optimizer.zero_grad()
+    labels = torch.randn(batch_size, 5).to(device)
+
+    outputs = ddp_model(torch.randn(batch_size, 10).to(device))
+    loss_fn(outputs, labels).backward()
+    optimizer.step()
+
+    # if rank == 0:
+    #     print(model.net1.weight)
+
+    weight.copy_(model.net1.weight.data.cpu())
+
+    del ddp_model
+    cleanup()
+
+
+def debug(rank, world_size, tensor, dp, noise_multiplier=0, max_grad_norm=1e8):
+    local_rank = setup_and_get_device(rank, world_size)
+    print(f"Rank: {rank},World size: {world_size}, local_rank: {local_rank}")
+    tensor = tensor.to(local_rank)
+    print(f"dp: {dp}")
+    print(tensor)
+
+    cleanup()
+
+
+def run_function(local_function, tensor, dp, noise_multiplier=0, max_grad_norm=1e8):
+    if os.environ.get("SLURM_NTASKS") is not None:
+        world_size = int(os.environ.get("SLURM_NTASKS"))
+        rank = int(os.environ.get("SLURM_PROCID"))
+        print(f"Running on a Slurm cluster with {world_size} tasks.")
+
+        local_function(rank, world_size, tensor, dp, noise_multiplier, max_grad_norm)
+    else:
+        world_size = torch.cuda.device_count()
+        print(f"Spawning multiple processes on a local machine with {world_size} GPUs")
+
+        # The rank will be passed as the first argument
+        mp.spawn(
+            local_function,
+            args=(
+                world_size,
+                tensor,
+                dp,
+                noise_multiplier,
+                max_grad_norm,
+            ),
+            nprocs=world_size,
+            join=True,
+        )
+    return world_size
+
+
+class GradientComputationTest(unittest.TestCase):
+    def test_connection(self):
+        tensor = torch.zeros(10, 10)
+        world_size = run_function(debug, tensor, dp=True)
+
+        self.assertTrue(
+            world_size >= 2, f"Need at least 2 gpus but was provided only {world_size}."
+        )
+
+    def test_gradient_noclip_zeronoise(self):
+        # Tests that gradient is the same with DP or with DDP
+        weight_dp, weight_nodp = torch.zeros(10, 10), torch.zeros(10, 10)
+
+        run_function(demo_basic, weight_dp, dp=True)
+        run_function(demo_basic, weight_nodp, dp=False)
+
+        self.assertTrue(torch.norm(weight_dp - weight_nodp) < 1e-7)
+
+    def test_ddp_hook(self):
+        # Tests that the DDP hook does the same thing as naive aggregation with per layer clipping
+        weight_ddp_naive, weight_ddp_hook = torch.zeros(10, 10), torch.zeros(10, 10)
+
+        run_function(
+            demo_basic,
+            weight_ddp_naive,
+            dp=True,
+            noise_multiplier=0.1,
+            max_grad_norm=1.0,
+        )
+
+        run_function(
+            demo_ddp_hook,
+            weight_ddp_hook,
+            dp=True,
+            noise_multiplier=0.1,
+            max_grad_norm=1.0,
+        )
+
+        # print(f"Naive DDP weight:")
+        # print(weight_ddp_naive)
+        # print("DDP hook weight:")
+        # print(weight_ddp_hook)
+
+        self.assertTrue(torch.norm(weight_ddp_naive - weight_ddp_hook) < 1e-7)

--- a/opacus/tests/ddp_hook_test.py
+++ b/opacus/tests/ddp_hook_test.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import os
-import sys
-import unittest
-import time
 import random
+import sys
+import time
+import unittest
 from unittest.main import main
 
 import torch
@@ -15,7 +15,6 @@ import torch.optim as optim
 from opacus import PrivacyEngine
 from opacus.layers import DifferentiallyPrivateDistributedDataParallel as DPDDP
 from torch.nn.parallel import DistributedDataParallel as DDP
-
 
 PRIVACY_ALPHAS = [1 + x / 10.0 for x in range(1, 100)] + list(range(12, 64))
 
@@ -112,9 +111,7 @@ def demo_basic(rank, world_size, weight, dp, noise_multiplier=0, max_grad_norm=1
             sample_size=10 * batch_size,
             alphas=PRIVACY_ALPHAS,
             noise_multiplier=noise_multiplier,
-            max_grad_norm=max_grad_norm,
-            experimental=True,
-            clip_per_layer=True,
+            max_grad_norm=[max_grad_norm],
         )
         engine.random_number_generator = engine._set_seed(0)
     else:
@@ -168,9 +165,7 @@ def demo_ddp_hook(rank, world_size, weight, dp, noise_multiplier, max_grad_norm)
             sample_size=10 * batch_size,
             alphas=PRIVACY_ALPHAS,
             noise_multiplier=noise_multiplier,
-            max_grad_norm=max_grad_norm,
-            experimental=True,
-            clip_per_layer=True,
+            max_grad_norm=[max_grad_norm],
         )
         engine.random_number_generator = engine._set_seed(0)
 

--- a/opacus/tests/docstring_examples_test.py
+++ b/opacus/tests/docstring_examples_test.py
@@ -17,6 +17,7 @@ from opacus.utils.module_modification import (
 )
 from opacus.utils.tensor_utils import (
     calc_sample_norms,
+    calc_sample_norms_one_layer,
     sum_over_all_but_batch_and_last_n,
 )
 
@@ -166,6 +167,10 @@ class DocstringExamplesTest(unittest.TestCase):
 
         self.assertTrue(
             calc_sample_norms([("1", t1), ("2", t2)])[0].shape, torch.Size([1, 2])
+        )
+
+        self.assertTrue(
+            (calc_sample_norms_one_layer(t1) == calc_sample_norms([("1", t1)])[0]).all()
         )
 
         tensor = torch.ones(1, 2, 3, 4, 5)

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -394,7 +394,7 @@ class PrivacyEngine_test(unittest.TestCase):
 
         optimizer.privacy_engine._set_seed(20)
         noise_generated_before = [
-            optimizer.privacy_engine._generate_noise(max_norm, p).detach().numpy()
+            optimizer.privacy_engine._generate_noise(max_norm, p.grad).detach().numpy()
             for p in model_params
         ]
 
@@ -403,7 +403,7 @@ class PrivacyEngine_test(unittest.TestCase):
 
         optimizer.privacy_engine._set_seed(20)
         noise_generated_after = [
-            optimizer.privacy_engine._generate_noise(max_norm, p).detach().numpy()
+            optimizer.privacy_engine._generate_noise(max_norm, p.grad).detach().numpy()
             for p in model_params
         ]
 

--- a/opacus/utils/tensor_utils.py
+++ b/opacus/utils/tensor_utils.py
@@ -42,6 +42,34 @@ def calc_sample_norms(
     return norms
 
 
+def calc_sample_norms_one_layer(param: torch.Tensor) -> torch.Tensor:
+    r"""
+    Calculates the norm of the given tensor (a single parameter) for each sample.
+
+    This function calculates the overall norm of the given tensor for each sample,
+    assuming the each batch's dim is zero.
+
+    It is equivalent to:
+    ```
+        calc_sample_norms(named_params=((None, param),))[0]
+    ```
+
+    Args:
+        param: A tensor of shape ``[B, ...]`` where ``B``
+            is the size of the batch and is the 0th dimension.
+
+    Example:
+        >>> t1 = torch.rand((2, 5))
+        >>> calc_sample_norms_one_layer(t1)
+            tensor([1.4757, 0.8128])
+
+    Returns:
+        A tensor of norms
+    """
+    norms = param.view(len(param), -1).norm(2, dim=-1)
+    return norms
+
+
 def sum_over_all_but_batch_and_last_n(
     tensor: torch.Tensor, n_dims: int
 ) -> torch.Tensor:

--- a/opacus/utils/uniform_sampler.py
+++ b/opacus/utils/uniform_sampler.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from typing import Optional
+
 import torch
 from torch.utils.data import Sampler
 
@@ -49,3 +51,107 @@ class UniformWithReplacementSampler(Sampler):
                 # This is compensated by the privacy engine
                 yield indices
             num_batches -= 1
+
+
+
+
+class DistributedPoissonBatchSampler(Sampler):
+    """
+    Distributed batch sampler.
+
+    Each batch is sampled as follows:
+        1. Shuffle the dataset (enabled by default)
+        2. Split the dataset among the replicas into chunks of equal size
+           (plus or minus one sample)
+        3. Each replica selects each sample of its chunk independently
+           with probability `sample_rate`
+        4. Each replica ouputs the selected samples, which form a local batch
+
+    The sum of the lengths of the local batches follows a Poisson distribution.
+    In particular, the expected length of each local batch is:
+        `sample_rate * total_size / num_replicas`
+    """
+
+    def __init__(
+        self,
+        total_size: int,
+        sample_rate: float,
+        num_replicas: Optional[int] = None,
+        rank: Optional[int] = None,
+        shuffle: bool = True,
+        seed: int = 0,
+        generator=None,
+    ):
+        self.total_size = total_size
+        self.sample_rate = sample_rate
+        self.generator = generator
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.epoch = 0
+        self.shuffle = shuffle
+        self.seed = seed
+        if self.generator is None:
+            generator = torch.Generator()
+            generator.manual_seed(
+                int(torch.empty((), dtype=torch.int64).random_().item())
+            )
+
+        if self.total_size <= 0:
+            raise ValueError(
+                "total_size should be a positive integer "
+                "value, but got total_size={}".format(self.total_size)
+            )
+
+        # Size of the local dataset specific to the current replica
+        self.num_samples = self.total_size // self.num_replicas
+        if self.rank < self.total_size % self.num_replicas:
+            # The first replicas get an extra datapoint if necessary (balanced)
+            self.num_samples += 1
+
+        # Number of batches: same as non-distributed Poisson sampling, but each batch is smaller
+        self.num_batches = int(1 / self.sample_rate)
+
+    def __len__(self) -> int:
+        return self.num_batches
+
+    def __iter__(self):
+        if self.shuffle:
+            # deterministically shuffle based on epoch and seed
+            g = torch.Generator()
+            g.manual_seed(self.seed + self.epoch)
+            indices = torch.randperm(self.total_size, generator=g)  # type: ignore
+        else:
+            indices = torch.arange(self.total_size)  # type: ignore
+
+        # Subset of the dataset assigned to this replica
+        # NOTE: the first replicas might have 1 more sample.
+        # (Different from the regular distributed loader that pads with more samples)
+        indices = indices[self.rank : self.total_size : self.num_replicas]
+        assert len(indices) == self.num_samples
+
+        # Now, select a batch with Poisson subsampling
+        for _ in range(self.num_batches):
+            mask = (
+                torch.rand(self.num_samples, generator=self.generator)
+                < self.sample_rate
+            )
+            selected_examples = mask.nonzero(as_tuple=False).reshape(-1)
+            if len(selected_examples) > 0:
+                yield indices[selected_examples]
+
+    def __len__(self) -> int:
+        """
+        Expected number of batches.
+        """
+        return self.num_batches
+
+    def set_epoch(self, epoch: int) -> None:
+        r"""
+        Sets the epoch for this sampler. When :attr:`shuffle=True`, this ensures all replicas
+        use a different random ordering for each epoch. Otherwise, the next iteration of this
+        sampler will yield the same ordering.
+
+        Args:
+            epoch (int): Epoch number.
+        """
+        self.epoch = epoch


### PR DESCRIPTION
This PR starts to add support for PyTorch DDP as proposed in https://github.com/pytorch/opacus/issues/191 (cc @thomasflynn918 @aik7).
We ported our code to a more recent version of Opacus, but there are still some changes to discuss, in particular how to plug the DDP hook into GradSample module. 

I also fixed some bugs related to distributed training (see below) in the same PR. I'm happy to open separate PRs to merge these smaller changes separately if you prefer.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

More context in this issue: https://github.com/pytorch/opacus/issues/191.

This PR:
- Added a prototype for the DDP hook in `grad_sample_module.py`
- Added distributed Poisson sampling
- Updated the CIFAR10 end-to-end example (with Slurm cluster support)
- Fixed bugs in the tests and examples where all the GPUs were working
on the same data
- Fixed bugs in the naive distributed training implementation (missing
initial synchronization, attempt to do allreduce on parameters without
gradients)
- Fixed bug where DPDDP was not detected, because the privacy engine was checking `self.privacy_engine.module` instead of looking inside the GradSample module `self.privacy_engine.module._module`.

## How Has This Been Tested (if it applies)

- Added tests to compare the weights with/without DDP hook

## Checklist

- [ ] The documentation is up-to-date with the changes I made.
*(this is still work in progress, I'll update the documentation once we agree on the API)*
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

## TODO

- [x] Validate how the hook is plugged into the GradSample module
- [x] Add support for empty Poisson batches in the hook
- [x] Ensure that the privacy accounting is still accurate with DDP
- [x] Generate the noise only on the GPU that needs it, to save some time (especially with CSPRNG)
- [x] Support per-layer clipping with different thresholds for each layer
