### PR TITLE
Update Opacus to stop using deprecated torch.set_deterministic

### DIFF
--- a/opacus/tests/dp_layers/common.py
+++ b/opacus/tests/dp_layers/common.py
@@ -121,7 +121,7 @@ class DPModules_test(unittest.TestCase):
                 - The values for any output ``nn_out`` in ``nn_outs`` differ by more
                     than `atol + rtol * abs(nn_out)`
         """
-        torch.set_deterministic(True)
+        torch.use_deterministic_algorithms(True)
         torch.manual_seed(0)
         np.random.seed(0)
 

--- a/opacus/tests/grad_samples/common.py
+++ b/opacus/tests/grad_samples/common.py
@@ -107,7 +107,7 @@ class GradSampleHooks_test(unittest.TestCase):
         Returns:
             Dictionary mapping parameter_name -> per-sample-gradient for that parameter
         """
-        torch.set_deterministic(True)
+        torch.use_deterministic_algorithms(True)
         torch.manual_seed(0)
         np.random.seed(0)
 
@@ -171,7 +171,7 @@ class GradSampleHooks_test(unittest.TestCase):
         Returns:
             Dictionary mapping parameter_name -> per-sample-gradient for that parameter
         """
-        torch.set_deterministic(True)
+        torch.use_deterministic_algorithms(True)
         torch.manual_seed(0)
         np.random.seed(0)
 


### PR DESCRIPTION
Differential Revision: D29940449

