### PR TITLE
Better validation error reporting

### DIFF
--- a/opacus/dp_model_inspector.py
+++ b/opacus/dp_model_inspector.py
@@ -36,7 +36,7 @@ class DPModelInspector:
             ModelInspector(
                 name="validity",
                 predicate=_is_valid_check,
-                message="Some modules are not valid.",
+                message="No grad sampler method found",
             ),
             # Inspector to check for BatchNorms as they could be replaced with groupnorm
             ModelInspector(
@@ -49,7 +49,7 @@ class DPModelInspector:
             ModelInspector(
                 name="running_stats",
                 predicate=_no_running_stats_instancenorm_check,
-                message="InstanceNorm layer initialised with track_running_stats=True."
+                message="InstanceNorm layer initialised with track_running_stats=True"
                 "This is currently not supported",
             ),
             # Inspector to check the number of groups in Conv2d layers

--- a/opacus/utils/module_inspection.py
+++ b/opacus/utils/module_inspection.py
@@ -69,10 +69,10 @@ class ModelInspector:
             Flag indicate if predicate is satisfied.
         """
         valid = True
-        for name, module in model.named_modules(prefix="Main"):
+        for name, module in model.named_modules():
             if not self.predicate(module):
                 valid = False
-                self.violators.append(name)
+                self.violators.append(f"{name} ({get_layer_type(module)})")
         return valid
 
 


### PR DESCRIPTION
Summary:
Existing validation errors can be confusing.

1) Message "Some modules are not valid" actually means "It could be valid, but we just don't know how to compute per sample gradient for it"
2) For violating layers we print only their name, but not the type. Sometimes names could be confusing, e.g. "_module.layer2.0.downsample.1"

This diff address both issues

Differential Revision: D29961632

