### PR TITLE
[experimental_v1.0] New PrivacyEngine prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,9 @@ website/build/
 website/i18n/
 website/node_modules/
 
+# PyCharm
+.idea/
+
 ## Generated for tutorials
 website/_tutorials/
 website/static/files/

--- a/opacus/accountant.py
+++ b/opacus/accountant.py
@@ -1,0 +1,10 @@
+class RDPAccountant:
+    def __init__(self):
+        self.steps = []
+
+    def step(self, noise_multiplier, sample_rate):
+        self.steps.append((noise_multiplier, sample_rate))
+
+    def get_privacy_spent(self, delta, alphas):
+        # TODO: well you know
+        return 0, 1

--- a/opacus/data_loader.py
+++ b/opacus/data_loader.py
@@ -1,0 +1,79 @@
+import torch
+from typing import Optional, Sequence
+from torch.utils.data import DataLoader, Dataset
+from torch.utils.data.dataloader import _worker_init_fn_t, _collate_fn_t
+from opacus.utils.uniform_sampler import UniformWithReplacementSampler
+from torch.utils.data._utils.collate import default_collate
+
+
+def wrap_collate_with_empty(collate_fn: Optional[_collate_fn_t], sample_empty_shapes: Sequence):
+    #TODO: does it work with padding and packed sequences?
+    def collate(batch):
+        if len(batch) > 0:
+            return collate_fn(batch)
+        else:
+            return [torch.zeros(x) for x in sample_empty_shapes]
+
+    return collate
+
+
+def shape_safe(x):
+    if hasattr(x, "shape"):
+        return x.shape
+    else:
+        return ()
+
+
+class DPDataLoader(DataLoader):
+
+    def __init__(self, dataset: Dataset, sample_rate: float,
+                 num_workers: int = 0, collate_fn: Optional[_collate_fn_t] = None,
+                 pin_memory: bool = False, drop_last: bool = False,
+                 timeout: float = 0, worker_init_fn: Optional[_worker_init_fn_t] = None,
+                 multiprocessing_context=None, generator=None,
+                 *, prefetch_factor: int = 2,
+                 persistent_workers: bool = False):
+
+        self.sample_rate = sample_rate
+        batch_sampler = UniformWithReplacementSampler(
+            num_samples=len(dataset), # type: ignore[assignment, arg-type]
+            sample_rate=sample_rate,
+            generator=generator,
+        )
+        sample_empty_shapes = [[0, *shape_safe(x)] for x in dataset[0]]
+        if collate_fn is None:
+            collate_fn = default_collate
+
+        super().__init__(
+            dataset=dataset,
+            batch_sampler=batch_sampler,
+            num_workers=num_workers,
+            collate_fn=wrap_collate_with_empty(collate_fn, sample_empty_shapes),
+            pin_memory=pin_memory,
+            drop_last=drop_last,
+            timeout=timeout,
+            worker_init_fn=worker_init_fn,
+            multiprocessing_context=multiprocessing_context,
+            generator=generator,
+            prefetch_factor=prefetch_factor,
+            persistent_workers=persistent_workers,
+        )
+
+    @classmethod
+    def from_data_loader(cls, data_loader: DataLoader):
+        if isinstance(data_loader, cls):
+            return data_loader
+
+        return cls(
+            dataset=data_loader.dataset,
+            sample_rate=1/len(data_loader),
+            num_workers=data_loader.num_workers,
+            pin_memory=data_loader.pin_memory,
+            drop_last=data_loader.drop_last,
+            timeout=data_loader.timeout,
+            worker_init_fn=data_loader.worker_init_fn,
+            multiprocessing_context=data_loader.multiprocessing_context,
+            generator=data_loader.generator,
+            prefetch_factor=data_loader.prefetch_factor,
+            persistent_workers=data_loader.persistent_workers
+        )

--- a/opacus/optimizer.py
+++ b/opacus/optimizer.py
@@ -6,8 +6,7 @@ import torch
 from torch import nn
 
 
-
-def _generate_noise(std: float, reference: nn.parameter.Parameter) -> torch.Tensor:
+def _generate_noise(std: float, reference: torch.Tensor) -> torch.Tensor:
     if std > 0:
         return torch.normal(
             mean=0,
@@ -65,7 +64,7 @@ class DPOptimizer(Optimizer):
 
     def clip_and_accumulate(self):
         per_param_norms = [x.view(len(x), -1).norm(2, dim=-1) for x in self.grad_samples]
-        per_sample_norms = torch.stack(per_param_norms, dim=0).norm(2, dim=0)
+        per_sample_norms = torch.stack(per_param_norms, dim=1).norm(2, dim=1)
         per_sample_clip_factor = (self.max_grad_norm / (per_sample_norms + 1e-6)).clamp(max=1.0)
 
         for p in self.params:
@@ -115,3 +114,5 @@ class DPOptimizer(Optimizer):
     def virtual_step(self):
         self.accumulated_iterations += 1
         self.clip_and_accumulate()
+
+    #TODO: wrap the rest of optim.Optimizer interface

--- a/opacus/optimizer.py
+++ b/opacus/optimizer.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from torch.optim import Optimizer
+from typing import Callable, Optional, List
+import torch
+from torch import nn
+
+
+
+def _generate_noise(std: float, reference: nn.parameter.Parameter) -> torch.Tensor:
+    if std > 0:
+        return torch.normal(
+            mean=0,
+            std=std,
+            size=reference.shape,
+            device=reference.device,
+        )
+    return torch.zeros(reference.shape, device=reference.device)
+
+
+class DPOptimizer(Optimizer):
+
+    def __init__(self,
+                 optimizer: Optimizer,
+                 *,
+                 noise_multiplier: float,
+                 max_grad_norm: float,
+                 expected_batch_size: Optional[int],
+                 loss_reduction: str = "mean",
+    ):
+        if loss_reduction not in ("mean", "sum"):
+            raise ValueError(f"Unexpected value for loss_reduction: {loss_reduction}")
+
+        if loss_reduction == "mean" and expected_batch_size is None:
+            raise ValueError("You must provide expected batch size of the loss reduction is mean")
+
+        self.optimizer = optimizer
+        self.noise_multiplier = noise_multiplier
+        self.max_grad_norm = max_grad_norm
+        self.loss_reduction = loss_reduction
+        self.expected_batch_size = expected_batch_size
+        self.step_hook = None
+
+        self.accumulated_iterations = 0
+
+    @property
+    def params(self) -> List[nn.Parameter]:
+        ret = []
+        for param_group in self.optimizer.param_groups:
+            ret += [p for p in param_group['params'] if p.requires_grad]
+        return ret
+
+    @property
+    def grad_samples(self) -> List[torch.Tensor]:
+        ret = []
+        for p in self.params:
+            if not hasattr(p, "grad_sample"):
+                raise ValueError("Per sample gradient not found. Are you using GradSampleModule?")
+
+            ret.append(p.grad_sample)
+        return ret
+
+    def attach_step_hook(self, fn: Callable[[DPOptimizer], None]):
+        self.step_hook = fn
+
+    def clip_and_accumulate(self):
+        per_param_norms = [x.view(len(x), -1).norm(2, dim=-1) for x in self.grad_samples]
+        per_sample_norms = torch.stack(per_param_norms, dim=0).norm(2, dim=0)
+        per_sample_clip_factor = (self.max_grad_norm / (per_sample_norms + 1e-6)).clamp(max=1.0)
+
+        for p in self.params:
+            grad = torch.einsum("i,i...", per_sample_clip_factor, p.grad_sample)
+
+            if hasattr(p, "summed_grad"):
+                p.summed_grad += grad
+            else:
+                p.summed_grad = grad
+
+    def add_noise(self):
+        for p in self.params:
+            noise = _generate_noise(self.noise_multiplier * self.max_grad_norm, p.summed_grad)
+            p.grad = p.summed_grad + noise
+
+    def scale_grad(self):
+        if self.loss_reduction == "mean":
+            for p in self.params:
+                p.grad /= (self.expected_batch_size * self.accumulated_iterations)
+
+    # TODO: see GradSampleModule.zero_grad()
+    # TODO: actually, not calling zero_grad() after step() does break privacy accounting - add warning?
+    def zero_grad(self, set_to_none: bool = False):
+        for p in self.params:
+            if hasattr(p, "grad_sample"):
+                del p.grad_sample
+            if hasattr(p, "summed_grad"):
+                del p.summed_grad
+
+        self.optimizer.zero_grad(set_to_none)
+
+    def step(self, closure: Optional[Callable[[], float]]=None) -> Optional[float]:
+        self.accumulated_iterations += 1
+
+        self.clip_and_accumulate()
+        self.add_noise()
+        self.scale_grad()
+
+        if self.step_hook:
+            self.step_hook(self)
+
+        self.accumulated_iterations = 0
+        return self.optimizer.step(closure)
+
+    # TODO: potentially refactor to decouple memory wins from accounting/averaging
+    # TODO: We can potentially track virtual steps automatically (through GSM.forward() or empty activatons lists)
+    def virtual_step(self):
+        self.accumulated_iterations += 1
+        self.clip_and_accumulate()

--- a/opacus/privacy_analysis.py
+++ b/opacus/privacy_analysis.py
@@ -27,11 +27,12 @@ Example:
 """
 
 import math
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Optional
 
 import numpy as np
 from scipy import special
 
+DEFAULT_ALPHAS = [1 + x / 10.0 for x in range(1, 100)] + list(range(12, 64))
 
 ########################
 # LOG-SPACE ARITHMETIC #
@@ -309,3 +310,52 @@ def get_privacy_spent(
 
     idx_opt = np.nanargmin(eps)  # Ignore NaNs
     return eps[idx_opt], orders_vec[idx_opt]
+
+
+def get_noise_multiplier(
+    target_epsilon: float,
+    target_delta: float,
+    sample_rate: float,
+    epochs: int,
+    alphas: Optional[List[float]] = None,
+    sigma_min: Optional[float] = 0.01,
+    sigma_max: Optional[float] = 10.0,
+) -> float:
+    r"""
+    Computes the noise level sigma to reach a total budget of (target_epsilon, target_delta)
+    at the end of epochs, with a given sample_rate
+    Args:
+        target_epsilon: the privacy budget's epsilon
+        target_delta: the privacy budget's delta
+        sample_rate: the sampling rate (usually batch_size / n_data)
+        epochs: the number of epochs to run
+        alphas: the list of orders at which to compute RDP
+    Returns:
+        The noise level sigma to ensure privacy budget of (target_epsilon, target_delta)
+    """
+    if alphas is None:
+        alphas = DEFAULT_ALPHAS
+
+    eps = float("inf")
+    while eps > target_epsilon:
+        sigma_max = 2 * sigma_max
+        rdp = compute_rdp(
+            sample_rate, sigma_max, epochs / sample_rate, alphas
+        )
+        eps = get_privacy_spent(alphas, rdp, target_delta)[0]
+        if sigma_max > 2000:
+            raise ValueError("The privacy budget is too low.")
+
+    while sigma_max - sigma_min > 0.01:
+        sigma = (sigma_min + sigma_max) / 2
+        rdp = compute_rdp(
+            sample_rate, sigma, epochs / sample_rate, alphas
+        )
+        eps = get_privacy_spent(alphas, rdp, target_delta)[0]
+
+        if eps < target_epsilon:
+            sigma_max = sigma
+        else:
+            sigma_min = sigma
+
+    return sigma

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -17,7 +17,7 @@ class PrivacyEngine:
         self.accountant = RDPAccountant()
         self.secure_mode = secure_mode # TODO: actually support it
 
-    def prepare(
+    def make_private(
             self,
             module: nn.Module,
             optimizer: optim.Optimizer,
@@ -54,7 +54,7 @@ class PrivacyEngine:
 
         return module, optimizer, data_loader
 
-    def prepare_with_epsilon(
+    def make_private_with_epsilon(
             self,
             module: nn.Module,
             optimizer: optim.Optimizer,

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -1,659 +1,92 @@
-#!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-
-import math
-import os
-import types
-import warnings
-from typing import List, Optional, Tuple, Union
-
-import torch
-from opacus.grad_sample import GradSampleModule
-from scipy.stats import planck
-from torch import nn
-
-from . import privacy_analysis
-from .dp_model_inspector import DPModelInspector
-from .layers.dp_ddp import (
-    DifferentiallyPrivateDistributedDataParallel,
-    average_gradients,
-)
-from .per_sample_gradient_clip import PerSampleGradientClipper
-from .utils import clipping
-
+from torch import nn, optim
+from torch.utils.data import DataLoader
+from opacus.accountant import RDPAccountant
+from opacus.grad_sample.grad_sample_module import GradSampleModule
+from opacus.optimizer import DPOptimizer
+from opacus.data_loader import DPDataLoader
 
 DEFAULT_ALPHAS = [1 + x / 10.0 for x in range(1, 100)] + list(range(12, 64))
 
 
-def get_noise_multiplier(
-    target_epsilon: float,
-    target_delta: float,
-    sample_rate: float,
-    epochs: int,
-    alphas: List[float],
-    sigma_min: Optional[float] = 0.01,
-    sigma_max: Optional[float] = 10.0,
-) -> float:
-    r"""
-    Computes the noise level sigma to reach a total budget of (target_epsilon, target_delta)
-    at the end of epochs, with a given sample_rate
-
-    Args:
-        target_epsilon: the privacy budget's epsilon
-        target_delta: the privacy budget's delta
-        sample_rate: the sampling rate (usually batch_size / n_data)
-        epochs: the number of epochs to run
-        alphas: the list of orders at which to compute RDP
-
-    Returns:
-        The noise level sigma to ensure privacy budget of (target_epsilon, target_delta)
-
-    """
-    eps = float("inf")
-    while eps > target_epsilon:
-        sigma_max = 2 * sigma_max
-        rdp = privacy_analysis.compute_rdp(
-            sample_rate, sigma_max, epochs / sample_rate, alphas
-        )
-        eps = privacy_analysis.get_privacy_spent(alphas, rdp, target_delta)[0]
-        if sigma_max > 2000:
-            raise ValueError("The privacy budget is too low.")
-
-    while sigma_max - sigma_min > 0.01:
-        sigma = (sigma_min + sigma_max) / 2
-        rdp = privacy_analysis.compute_rdp(
-            sample_rate, sigma, epochs / sample_rate, alphas
-        )
-        eps = privacy_analysis.get_privacy_spent(alphas, rdp, target_delta)[0]
-
-        if eps < target_epsilon:
-            sigma_max = sigma
-        else:
-            sigma_min = sigma
-
-    return sigma
-
-
 class PrivacyEngine:
-    r"""
-    The main component of Opacus is the ``PrivacyEngine``.
 
-    To train a model with differential privacy, all you need to do
-    is to define a ``PrivacyEngine`` and later attach it to your
-    optimizer before running.
+    def __init__(self, secure_mode=False):
+        self.accountant = RDPAccountant()
+        self.secure_mode = secure_mode # TODO: actually support it
 
-
-    Example:
-        This example shows how to define a ``PrivacyEngine`` and to attach
-        it to your optimizer.
-
-        >>> import torch
-        >>> model = torch.nn.Linear(16, 32)  # An example model
-        >>> optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
-        >>> privacy_engine = PrivacyEngine(model, sample_rate=0.01, noise_multiplier=1.3, max_grad_norm=1.0)
-        >>> privacy_engine.attach(optimizer)  # That's it! Now it's business as usual.
-    """
-
-    # flake8: noqa: C901
-    def __init__(
-        self,
-        module: nn.Module,
-        *,  # As per PEP 3102, this forces clients to specify kwargs explicitly, not positionally
-        sample_rate: Optional[float] = None,
-        batch_size: Optional[int] = None,
-        sample_size: Optional[int] = None,
-        max_grad_norm: Union[float, List[float]],
-        noise_multiplier: Optional[float] = None,
-        alphas: List[float] = DEFAULT_ALPHAS,
-        secure_rng: bool = False,
-        batch_first: bool = True,
-        target_delta: float = 1e-6,
-        target_epsilon: Optional[float] = None,
-        epochs: Optional[float] = None,
-        loss_reduction: str = "mean",
-        poisson: bool = False,
-        **misc_settings,
+    # TODO cool name
+    def prepare(
+            self,
+            module: nn.Module,
+            optimizer: optim.Optimizer,
+            data_loader: DataLoader,
+            noise_multiplier: float,
+            max_grad_norm: float,
+            batch_first: bool = True,
+            loss_reduction: str = "mean",
     ):
-        r"""
-        Args:
-            module: The Pytorch module to which we are attaching the privacy engine
-            alphas: A list of RDP orders
-            noise_multiplier: The ratio of the standard deviation of the Gaussian noise to
-                the L2-sensitivity of the function to which the noise is added
-            max_grad_norm: The maximum norm of the per-sample gradients. Any gradient with norm
-                higher than this will be clipped to this value.
-            batch_size: Training batch size. Used in the privacy accountant.
-            sample_size: The size of the sample (dataset). Used in the privacy accountant.
-            sample_rate: Sample rate used to build batches. Used in the privacy accountant.
-            secure_rng: If on, it will use ``torchcsprng`` for secure random number generation.
-                Comes with a significant performance cost, therefore it's recommended that you
-                turn it off when just experimenting.
-            batch_first: Flag to indicate if the input tensor to the corresponding module
-                has the first dimension representing the batch. If set to True, dimensions on
-                input tensor will be ``[batch_size, ..., ...]``.
-            target_delta: The target delta. If unset, we will set it for you.
-            loss_reduction: Indicates if the loss reduction (for aggregating the gradients)
-                is a sum or a mean operation. Can take values "sum" or "mean"
-            **misc_settings: Other arguments to the init
-        """
 
-        self.steps = 0
-        self.poisson = poisson
-        self.loss_reduction = loss_reduction
-        self.batch_size = batch_size
-        self.sample_size = sample_size
-        self.sample_rate = sample_rate
-        self._set_sample_rate()
+        # TODO: DP-Specific validation
 
-        if isinstance(module, DifferentiallyPrivateDistributedDataParallel):
-            rank = torch.distributed.get_rank()
-            n_replicas = torch.distributed.get_world_size()
-            self.sample_rate *= n_replicas
+        module = self._prepare_model(module, batch_first, loss_reduction)
+        data_loader = self._prepare_data_loader(data_loader)
+
+        sample_rate = 1 / len(data_loader)
+        expected_batch_size = int(len(data_loader.dataset) * sample_rate)
+
+        optimizer = self._prepare_optimizer(
+            optimizer=optimizer,
+            noise_multiplier=noise_multiplier,
+            max_grad_norm=max_grad_norm,
+            expected_batch_size=expected_batch_size,
+            loss_reduction=loss_reduction,
+        )
+
+        def accountant_hook(optim: DPOptimizer):
+            self.accountant.step(
+                noise_multiplier=optim.noise_multiplier,
+                sample_rate=sample_rate*optim.accumulated_iterations
+            )
+        optimizer.attach_step_hook(accountant_hook)
+
+        return module, optimizer, data_loader
+
+    def _prepare_model(self, module: nn.Module, batch_first: bool = True,
+                       loss_reduction: str = "mean", ) -> GradSampleModule:
+        if isinstance(module, GradSampleModule):
+            return module
         else:
-            rank = 0
-            n_replicas = 1
+            return GradSampleModule(module, batch_first=batch_first, loss_reduction=loss_reduction)
 
-        self.module = GradSampleModule(module)
+    def _prepare_optimizer(
+            self,
+            optimizer: optim.Optimizer,
+            noise_multiplier: float,
+            max_grad_norm: float,
+            expected_batch_size: int,
+            loss_reduction: str = "mean",
+    ) -> DPOptimizer:
+        if isinstance(optimizer, DPOptimizer):
+            # TODO: lol rename optimizer optimizer optimizer
+            optimizer = optimizer.optimizer
 
-        if poisson:
-            # TODO: Check directly if sampler is UniformSampler when sampler gets passed to the Engine (in the future)
-            if sample_size is None:
-                raise ValueError(
-                    "If using Poisson sampling, sample_size should get passed to the PrivacyEngine."
-                )
-
-            # Number of empty batches follows a geometric distribution
-            # Planck is the same distribution but its parameter is the (negative) log of the geometric's parameter
-            self._poisson_empty_batches_distribution = planck(
-                -math.log(1 - self.sample_rate) * self.sample_size
-            )
-
-        if noise_multiplier is None:
-            if target_epsilon is None or target_delta is None or epochs is None:
-                raise ValueError(
-                    "If noise_multiplier is not specified, (target_epsilon, target_delta, epochs) should be given to the engine."
-                )
-            self.noise_multiplier = get_noise_multiplier(
-                target_epsilon, target_delta, self.sample_rate, epochs, alphas
-            )
-        else:
-            self.noise_multiplier = noise_multiplier
-
-        self.max_grad_norm = max_grad_norm
-        self.alphas = alphas
-        self.target_delta = target_delta
-        self.secure_rng = secure_rng
-        self.batch_first = batch_first
-        self.misc_settings = misc_settings
-        self.n_replicas = n_replicas
-        self.rank = rank
-
-        self.device = next(module.parameters()).device
-        self.steps = 0
-
-        if self.noise_multiplier < 0:
-            raise ValueError(
-                f"noise_multiplier={self.noise_multiplier} is not a valid value. Please provide a float >= 0."
-            )
-
-        if isinstance(self.max_grad_norm, float) and self.max_grad_norm <= 0:
-            raise ValueError(
-                f"max_grad_norm={self.max_grad_norm} is not a valid value. Please provide a float > 0."
-            )
-
-        if not self.target_delta:
-            if self.sample_size:
-                warnings.warn(
-                    "target_delta unset. Setting it to an order of magnitude less than 1/sample_size."
-                )
-                self.target_delta = 0.1 * (1 / self.sample_size)
-            else:
-                raise ValueError("Please provide a target_delta.")
-
-        if self.secure_rng:
-            self.seed = None
-            try:
-                import torchcsprng as csprng
-            except ImportError as e:
-                msg = (
-                    "To use secure RNG, you must install the torchcsprng package! "
-                    "Check out the instructions here: https://github.com/pytorch/csprng#installation"
-                )
-                raise ImportError(msg) from e
-
-            self.seed = None
-            self.random_number_generator = csprng.create_random_device_generator(
-                "/dev/urandom"
-            )
-        else:
-            warnings.warn(
-                "Secure RNG turned off. This is perfectly fine for experimentation as it allows "
-                "for much faster training performance, but remember to turn it on and retrain "
-                "one last time before production with ``secure_rng`` turned on."
-            )
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                self.seed = int.from_bytes(os.urandom(8), byteorder="big", signed=True)
-                self.random_number_generator = self._set_seed(self.seed)
-
-        self.validator = DPModelInspector()
-        self.clipper = None  # lazy initialization in attach
-
-    def state_dict(self):
-        return {
-            "steps": self.steps,
-        }
-
-    def load_state_dict(self, state_dict):
-        self.steps = state_dict["steps"]
-
-    def detach(self):
-        r"""
-        Detaches the privacy engine from optimizer.
-
-        To detach the ``PrivacyEngine`` from optimizer, this method returns
-        the model and the optimizer to their original states (i.e. all
-        added attributes/methods will be removed).
-        """
-        # 1. Fix optimizer
-        optim = self.optimizer
-        optim.step = optim.original_step
-        delattr(optim, "privacy_engine")
-        delattr(optim, "original_step")
-        delattr(optim, "original_zero_grad")
-        delattr(optim, "virtual_step")
-
-        # 2. Fix module
-        self.module._close()
-
-    def attach(self, optimizer: torch.optim.Optimizer):
-        r"""
-        Attaches the privacy engine to the optimizer.
-
-        Attaches to the ``PrivacyEngine`` an optimizer object,and injects
-        itself into the optimizer's step. To do that it,
-
-        1. Validates that the model does not have unsupported layers.
-
-        2. Adds a pointer to this object (the ``PrivacyEngine``) inside the optimizer.
-
-        3. Moves optimizer's original ``step()`` function to ``original_step()``.
-
-        4. Monkeypatches the optimizer's ``step()`` function to call ``step()`` on
-        the query engine automatically whenever it would call ``step()`` for itself.
-
-        Args:
-            optimizer: The optimizer to which the privacy engine will attach
-        """
-        if hasattr(optimizer, "privacy_engine"):
-            if optimizer.privacy_engine != self:
-                raise ValueError(
-                    f"Trying to attach to optimizer: {optimizer}, but that optimizer is "
-                    f"already attached to a different Privacy Engine: {optimizer.privacy_engine}."
-                )
-            else:
-                warnings.warn(
-                    "Trying to attach twice to the same optimizer. Nothing to do."
-                )
-                return
-
-        self.validator.validate(self.module)
-        norm_clipper = (
-            clipping.ConstantFlatClipper(self.max_grad_norm)
-            if not isinstance(self.max_grad_norm, list)
-            else clipping.ConstantPerLayerClipper(self.max_grad_norm)
+        return DPOptimizer(
+            optimizer=optimizer,
+            noise_multiplier=noise_multiplier,
+            max_grad_norm=max_grad_norm,
+            expected_batch_size=expected_batch_size,
+            loss_reduction=loss_reduction
         )
 
-        if self.misc_settings.get("experimental", False):
-            norm_clipper = clipping._Dynamic_Clipper_(
-                [self.max_grad_norm],
-                self.misc_settings.get("clip_per_layer", False),
-                self.misc_settings.get(
-                    "clipping_method", clipping.ClippingMethod.STATIC
-                ),
-                self.misc_settings.get("clipping_ratio", 0.0),
-                self.misc_settings.get("clipping_momentum", 0.0),
-            )
+    def _prepare_data_loader(self, data_loader: DataLoader) -> DPDataLoader:
+        if isinstance(data_loader, DPDataLoader):
+            return data_loader
 
-        self.clipper = PerSampleGradientClipper(
-            self.module,
-            norm_clipper,
-            self.batch_first,
-            self.loss_reduction,
-        )
+        return DPDataLoader.from_data_loader(data_loader)
 
-        def dp_zero_grad(self):
-            self.privacy_engine.zero_grad()
-            self.original_zero_grad()
+    # TODO: default delta value?
+    def get_privacy_spent(self, delta, alphas=None):
+        if not alphas:
+            alphas = DEFAULT_ALPHAS
 
-        def dp_step(self, closure=None, is_empty=False):
-            self.privacy_engine.step(is_empty)
-            if isinstance(
-                self.privacy_engine.module, DifferentiallyPrivateDistributedDataParallel
-            ):
-                average_gradients(self.privacy_engine.module)
-            self.original_step(closure)
-
-        def poisson_dp_step(self, closure=None):
-            # Perform one step as usual
-            self.dp_step(closure)
-
-            # Taking empty steps to simulate empty batches
-            num_empty_batches = self.privacy_engine._sample_poisson_empty_batches()
-            for _ in range(num_empty_batches):
-                self.zero_grad()
-                self.dp_step(closure, is_empty=True)
-
-        optimizer.privacy_engine = self
-
-        optimizer.dp_step = types.MethodType(dp_step, optimizer)
-        optimizer.original_step = optimizer.step
-        optimizer.step = types.MethodType(
-            poisson_dp_step if self.poisson else dp_step, optimizer
-        )
-
-        optimizer.original_zero_grad = optimizer.zero_grad
-        optimizer.zero_grad = types.MethodType(dp_zero_grad, optimizer)
-
-        def virtual_step(self):
-            self.privacy_engine.virtual_step()
-
-        optimizer.virtual_step = types.MethodType(virtual_step, optimizer)
-
-        # create a cross reference for detaching
-        self.optimizer = optimizer
-
-        if self.poisson:
-            # Optional initial step on empty batch
-            num_empty_batches = self._sample_poisson_empty_batches()
-            for _ in range(num_empty_batches):
-                self.optimizer.zero_grad()
-                for p in self.module.parameters():
-                    if p.requires_grad:
-                        p.grad = torch.zeros_like(p)
-                self.optimizer.dp_step(closure=None, is_empty=True)
-
-    def _sample_poisson_empty_batches(self):
-        """
-        Samples an integer which is equal to the number of (consecutive) empty batches when doing Poisson sampling
-        """
-        return self._poisson_empty_batches_distribution.rvs(size=1)[0]
-
-    def get_renyi_divergence(self):
-        rdp = torch.tensor(
-            privacy_analysis.compute_rdp(
-                self.sample_rate, self.noise_multiplier, 1, self.alphas
-            )
-        )
-        return rdp
-
-    def get_privacy_spent(
-        self, target_delta: Optional[float] = None
-    ) -> Tuple[float, float]:
-        """
-        Computes the (epsilon, delta) privacy budget spent so far.
-
-        This method converts from an (alpha, epsilon)-DP guarantee for all alphas that
-        the ``PrivacyEngine`` was initialized with. It returns the optimal alpha together
-        with the best epsilon.
-
-        Args:
-            target_delta: The Target delta. If None, it will default to the privacy
-                engine's target delta.
-
-        Returns:
-            Pair of epsilon and optimal order alpha.
-        """
-        if target_delta is None:
-            if self.target_delta is None:
-                raise ValueError(
-                    "If self.target_delta is not specified, target_delta should be set as argument to get_privacy_spent."
-                )
-            target_delta = self.target_delta
-        rdp = self.get_renyi_divergence() * self.steps
-        eps, best_alpha = privacy_analysis.get_privacy_spent(
-            self.alphas, rdp, target_delta
-        )
-        return float(eps), float(best_alpha)
-
-    def zero_grad(self):
-        """
-        Resets clippers status.
-
-        Clipper keeps internal gradient per sample in the batch in each
-        ``forward`` call of the module, they need to be cleaned before the
-        next round.
-
-        If these variables are not cleaned the per sample gradients keep
-        being concatenated accross batches. If accumulating gradients
-        is intented behavious, e.g. simulating a large batch, prefer
-        using ``virtual_step()`` function.
-        """
-        if self.clipper is not None:
-            self.clipper.zero_grad()
-
-    def step(self, is_empty: bool = False):
-        """
-        Takes a step for the privacy engine.
-
-        Args:
-            is_empty: Whether the step is taken on an empty batch
-                In this case, we do not call clip_and_accumulate since there are no
-                per sample gradients.
-
-        Notes:
-            You should not call this method directly. Rather, by attaching your
-            ``PrivacyEngine`` to the optimizer, the ``PrivacyEngine`` would have
-            the optimizer call this method for you.
-
-        Raises:
-            ValueError: If the last batch of training epoch is greater than others.
-                This ensures the clipper consumed the right amount of gradients.
-                In the last batch of a training epoch, we might get a batch that is
-                smaller than others but we should never get a batch that is too large
-
-        """
-        self.steps += 1
-        if not is_empty:
-            self.clipper.clip_and_accumulate()
-            clip_values, batch_size = self.clipper.pre_step()
-        else:
-            clip_values = (
-                self.max_grad_norm
-                if type(self.max_grad_norm) is list
-                else [
-                    self.max_grad_norm
-                    for p in self.module.parameters()
-                    if p.requires_grad
-                ]
-            )
-            batch_size = self.avg_batch_size
-
-        params = (p for p in self.module.parameters() if p.requires_grad)
-        for p, clip_value in zip(params, clip_values):
-            noise = self._generate_noise(clip_value, p)
-            if self.loss_reduction == "mean":
-                noise /= batch_size
-
-            if self.rank == 0:
-                # Noise only gets added on first worker
-                # This is easy to reason about for loss_reduction=sum
-                # For loss_reduction=mean, noise will get further divided by
-                # world_size as gradients are averaged.
-                p.grad += noise
-
-            # For poisson, we are not supposed to know the batch size
-            # We have to divide by avg_batch_size instead of batch_size
-            if self.poisson and self.loss_reduction == "mean":
-                p.grad *= batch_size / self.avg_batch_size
-
-    def to(self, device: Union[str, torch.device]):
-        """
-        Moves the privacy engine to the target device.
-
-        Args:
-            device : The device on which Pytorch Tensors are allocated.
-                See: https://pytorch.org/docs/stable/tensor_attributes.html#torch.torch.device
-
-        Example:
-            This example shows the usage of this method, on how to move the model
-            after instantiating the ``PrivacyEngine``.
-
-            >>> model = torch.nn.Linear(16, 32)  # An example model. Default device is CPU
-            >>> privacy_engine = PrivacyEngine(model, sample_rate=0.01, noise_multiplier=0.8, max_grad_norm=0.5)
-            >>> device = "cuda:3"  # GPU
-            >>> model.to(device)  # If we move the model to GPU, we should call the to() method of the privacy engine (next line)
-            >>> privacy_engine.to(device)
-
-        Returns:
-            The current ``PrivacyEngine``
-        """
-        self.device = device
-        return self
-
-    def virtual_step(self):
-        r"""
-        Takes a virtual step.
-
-        Virtual batches enable training with arbitrary large batch sizes, while
-        keeping the memory consumption constant. This is beneficial, when training
-        models with larger batch sizes than standard models.
-
-        Example:
-            Imagine you want to train a model with batch size of 2048, but you can only
-            fit batch size of 128 in your GPU. Then, you can do the following:
-
-            >>> for i, (X, y) in enumerate(dataloader):
-            >>>     logits = model(X)
-            >>>     loss = criterion(logits, y)
-            >>>     loss.backward()
-            >>>     if i % 16 == 15:
-            >>>         optimizer.step()    # this will call privacy engine's step()
-            >>>         optimizer.zero_grad()
-            >>>     else:
-            >>>         optimizer.virtual_step()   # this will call privacy engine's virtual_step()
-
-            The rough idea of virtual step is as follows:
-
-            1. Calling ``loss.backward()`` repeatedly stores the per-sample gradients
-            for all mini-batches. If we call ``loss.backward()`` ``N`` times on
-            mini-batches of size ``B``, then each weight's ``.grad_sample`` field will
-            contain ``NxB`` gradients. Then, when calling ``step()``, the privacy engine
-            clips all ``NxB`` gradients and computes the average gradient for an effective
-            batch of size ``NxB``. A call to ``optimizer.zero_grad()`` erases the
-            per-sample gradients.
-
-            2. By calling ``virtual_step()`` after ``loss.backward()``,the ``B``
-            per-sample gradients for this mini-batch are clipped and summed up into a
-            gradient accumulator. The per-sample gradients can then be discarded. After
-            ``N`` iterations (alternating calls to ``loss.backward()`` and
-            ``virtual_step()``), a call to ``step()`` will compute the average gradient
-            for an effective batch of size ``NxB``.
-
-            The advantage here is that this is memory-efficient: it discards the per-sample
-            gradients after every mini-batch. We can thus handle batches of arbitrary size.
-        """
-        self.clipper.clip_and_accumulate()
-
-    def _generate_noise(
-        self, max_grad_norm: float, reference: nn.parameter.Parameter
-    ) -> torch.Tensor:
-        r"""
-        Generates a tensor of Gaussian noise of the same shape as ``reference``.
-
-        The generated tensor has zero mean and standard deviation
-        sigma = ``noise_multiplier x max_grad_norm ``
-
-        Args:
-            max_grad_norm : The maximum norm of the per-sample gradients.
-            reference : The reference, based on which the dimention of the
-                noise tensor will be determined
-
-        Returns:
-            the generated noise with noise zero and standard
-            deviation of ``noise_multiplier x max_grad_norm ``
-        """
-        if self.noise_multiplier > 0 and max_grad_norm > 0:
-            return torch.normal(
-                0,
-                self.noise_multiplier * max_grad_norm,
-                reference.grad.shape,
-                device=self.device,
-                generator=self.random_number_generator,
-            )
-        return torch.zeros(reference.grad.shape, device=self.device)
-
-    def _set_seed(self, seed: int):
-        r"""
-        Allows to manually set the seed allowing for a deterministic run. Useful if you want to
-        debug.
-
-        WARNING: MANUALLY SETTING THE SEED BREAKS THE GUARANTEE OF SECURE RNG.
-        For this reason, this method will raise a ValueError if you had ``secure_rng`` turned on.
-
-        Args:
-            seed : The **unsecure** seed
-        """
-        if self.secure_rng:
-            raise ValueError(
-                "Seed was manually set on a ``PrivacyEngine`` with ``secure_rng`` turned on."
-                "This fundamentally breaks secure_rng, and cannot be allowed. "
-                "If you do need reproducibility with a fixed seed, first instantiate the PrivacyEngine "
-                "with ``secure_seed`` turned off."
-            )
-        self.seed = seed
-
-        return (
-            torch.random.manual_seed(self.seed)
-            if self.device.type == "cpu"
-            else torch.cuda.manual_seed(self.seed)
-        )
-
-    def _set_sample_rate(self):
-        r"""
-        Determine the ``sample_rate``.
-
-        If a ``sample_rate`` is provided, it will be used.
-        If no ``sample_rate``is provided, the used ``sample_rate`` will be equal to
-        ``batch_size`` /  ``sample_size``.
-        """
-        if self.batch_size and not isinstance(self.batch_size, int):
-            raise ValueError(
-                f"batch_size={self.batch_size} is not a valid value. Please provide a positive integer."
-            )
-
-        if self.sample_size and not isinstance(self.sample_size, int):
-            raise ValueError(
-                f"sample_size={self.sample_size} is not a valid value. Please provide a positive integer."
-            )
-
-        if self.sample_rate is None:
-            if self.batch_size is None or self.sample_size is None:
-                raise ValueError(
-                    "You must provide (batch_size and sample_sizes) or sample_rate."
-                )
-            else:
-                self.sample_rate = self.batch_size / self.sample_size
-                if self.batch_size is not None or self.sample_size is not None:
-                    warnings.warn(
-                        "The sample rate will be defined from ``batch_size`` and ``sample_size``."
-                        "The returned privacy budget will be incorrect."
-                    )
-
-            self.avg_batch_size = self.sample_rate * self.sample_size
-        else:
-            warnings.warn(
-                "A ``sample_rate`` has been provided."
-                "Thus, the provided ``batch_size``and ``sample_size`` will be ignored."
-            )
-            if self.poisson:
-                if self.loss_reduction == "mean" and not self.sample_size:
-                    raise ValueError(
-                        "Sample size has to be provided if using Poisson and loss_reduction=mean."
-                    )
-                self.avg_batch_size = self.sample_rate * self.sample_size
-
-        if self.sample_rate > 1.0:
-            raise ValueError(
-                f"sample_rate={self.sample_rate} is not a valid value. Please provide a float between 0 and 1."
-            )
+        return self.accountant.get_privacy_spent(delta, alphas)

--- a/opacus/utils/uniform_sampler.py
+++ b/opacus/utils/uniform_sampler.py
@@ -44,8 +44,6 @@ class UniformWithReplacementSampler(Sampler):
                 < self.sample_rate
             )
             indices = mask.nonzero(as_tuple=False).reshape(-1).tolist()
-            if len(indices) != 0:
-                # We only output non-empty list of indices, otherwise the dataloader is unhappy
-                # This is compensated by the privacy engine
-                yield indices
+            yield indices
+
             num_batches -= 1


### PR DESCRIPTION
Disclaimer: it doesn't work yet. I've tested the design on some simple cases (MNIST example) to check it's valid, but all the tests will break and many features are missing

## Highlights

We embrace the concept of isolated decoupled modules with as few responsibilities as possible. They're all tied together into a simple API by PrivacyEngine.

We have:
- `GradSampleModule`. Already there. Responsible for computing per sample gradients and nothing else. Can be used outside of DP context.
- `DPOptimizer`. Wrapper around regular optimizer. Performs clipping and adds noise, then calls for underlying optimizer's `step`. Takes most of the core responsibilities previously owned by PrivacyEngine. Provides hooks to do accounting.
- `DPDataLoader`. Wrapper around regular data loader, but takes control over sampling. The rest is normal DataLoader. Side benefit: it also controls `collate` method, so we can handle 0-sized batches much more elegantly than today.

PrivacyEngine now becomes very minimalistic object, mostly providing a one-stop interface for the three classes above:
```
model = MyModule()
optimizer = optim.SGD(model.parameters(), lr=lr, momentum=0)
train_loader = DataLoader(<...>)

privacy_engine = PrivacyEngine()

model, optimizer, train_loader = privacy_engine.prepare(
    module=model,
    optimizer=optimizer,
    data_loader=train_loader,
    noise_multiplier=1.0,
    max_grad_norm=1.0
)
``` 

Also note the new interface for PrivacyAccountant - it opens up a road to variable noise and sampling rate:

```
	
class RDPAccountant:
    def __init__(self):
        self.steps = []

    def step(self, noise_multiplier, sample_rate):
        self.steps.append((noise_multiplier, sample_rate))

    def get_privacy_spent(self, delta, alphas):
        pass
```

Overall, I'm quite happy with how it's working out so far. There seem to be a clear responsibility split between `GradSampleModule`, `DPOptimizer`, `DPDataLoader` and `RDPAccountant`. There's surprisingly little code required for the basic DP-SGD implementation, which I really like. 
One thing I'm particularly happy about is that gradients are no longer updated in `NormClipper`, but in a more appropriate place.
 
More importantly, these modules can be used independently of each other. `PrivacyEngine` has become essentially a syntactic sugar - it just passes arguments to constructors with almost zero manipulations. It's a good feature to have for beginners, but I expect researches to be able to play around with privacy modules directly, not through privacy engine. More examples of that in the section below on how to do stuff

## How can I do X?

**variable noise**
You call `PrivacyEngine.prepare()` multiple times, changing the amount of noise or clipping threshold. Optimizer and accountant will pick up the change


**variable sampling rate**
You call `PrivacyEngine.prepare()` multiple times, changing the data loader.  Optimizer and accountant will pick up the change

**Different accounting**
You ditch PrivacyEngine and pass your accountant as a callback to `DPOptimizer`

**Different clipping**
You create a subclass of `DPOptimizer` and override `clip_and_accumulate()` method (potentially also constructor if you need extra arguments)

**Different noise**
Not sure why you'd want that, but you override a method in `DPOptimizer`

**I don't care for uniform sampling, give me batches back**
Ditch PrivacyEngine, use `GradSampleModule` and `DPOptimizer`


## What's next 
There's a lot to do, obviously, but I'll highlight some clearly visible gaps:

- Support DDP. I haven't yet looked into how it fits into the picture, but probably a subclass of `DPOptimizer` should do the job
- Implement different clipping strategies. Probably not required, but nice to have, especially in the context of [#196](https://github.com/pytorch/opacus/pull/196)
- Implement `RDPAccountant`
- Support PackedSequence and padded sequences in `DPDataLoader.collate_fn`
- Support `secure_mode`
- Current implementation of `DPOptimizer.zero_grad()` is sloppy and needs work
- DP model validation
- Current version support virtual steps, but there's a way to make them better. In normal pytorch you can just call forward multiple times before calling `optimizer.step` and that would be your virtual step. I think there's a way to do the same in opacus -  then you'll only need `optimizer.virtual_step` for memory management, gradients and noise will be adjusted automatically
- Tests, obviously 