### PR TITLE
Pass down batch_first parameter

### DIFF
--- a/opacus/layers/dp_multihead_attention.py
+++ b/opacus/layers/dp_multihead_attention.py
@@ -41,7 +41,7 @@ class SequenceBias(nn.Module):
 
     def _reset_parameters(self):
         r"""
-        assing's Normally distributed random values to bias.
+        assigns Normally distributed random values to bias.
         """
         nn.init.normal_(self.bias)
 

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -9,10 +9,11 @@ from functools import partial
 from typing import List, Optional, Tuple, Union
 
 import torch
-from opacus.grad_sample import GradSampleModule
-from opacus.utils.tensor_utils import calc_sample_norms_one_layer
 from scipy.stats import planck
 from torch import Tensor, nn
+
+from opacus.grad_sample import GradSampleModule
+from opacus.utils.tensor_utils import calc_sample_norms_one_layer
 
 from . import privacy_analysis
 from .dp_model_inspector import DPModelInspector
@@ -100,7 +101,8 @@ class PrivacyEngine:
     def __init__(
         self,
         module: nn.Module,
-        *,  # As per PEP 3102, this forces clients to specify kwargs explicitly, not positionally
+        *,
+        # As per PEP 3102, this forces clients to specify kwargs explicitly, not positionally
         sample_rate: Optional[float] = None,
         batch_size: Optional[int] = None,
         sample_size: Optional[int] = None,
@@ -157,7 +159,9 @@ class PrivacyEngine:
             rank = 0
             n_replicas = 1
 
-        self.module = GradSampleModule(module)
+        self.module = GradSampleModule(
+            module, batch_first=batch_first, loss_reduction=loss_reduction
+        )
 
         if poisson:
             # TODO: Check directly if sampler is UniformSampler when sampler gets passed to the Engine (in the future)


### PR DESCRIPTION
As noticed by @samdow, grad_samples doesn't look right when using `PrivacyEngine` with `batch_first=False`.

The problem is, since `GradSampleModule` was introduced, we don't pass down `batch_first` from `PrivacyEngine` to `GradSampleModule` (see `privacy_engine:162-164`)

In addition to that, none of our tests caught that: grad_sample tests use `GradSampleModule` directly and bypass PrivacyEngine, privacy_engine tests don't check `batch_first` case.

This PR fixed both issues:
- We initialize `GradSampleModule` with full set of parameters 
- in `privacy_engine_test.py` we introduce additional set of test cases: we now run all tests for two models: ConvNet (as before) and NLP model (Embedding + MultiheadAttention).
- We also add one more check to `privacy_engine_test.py`: `test_grad_sample_shape`. Surprisingly, even with the new NLP model, none of the existing test cases caught `batch_first` issue; when you aggregate over the first dimension, you get correct result despite having set `batch_first` wrong