### PR TITLE
PyTorch Lightning Demo (old API)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,28 @@ commands:
       - store_artifacts:
           path: runs/mnist/test-reports
 
+  mnist_lightning_integration_test:
+    description: "Runs MNIST-Lightning example end to end"
+    parameters:
+      device:
+        default: "cpu"
+        type: string
+    steps:
+      - run:
+          name: MNIST-Lightning example
+          command: |
+            mkdir -p runs/mnist/data
+            mkdir -p runs/mnist/test-reports
+            echo "Using $(python -V) ($(which python))"
+            echo "Using $(pip -V) ($(which pip))"
+            python examples/mnist_lightning.py fit --trainer.accelerator <<parameters.device>> --model.lr 0.25 --model.sigma 0.7 --model.max_per_sample_grad_norm 1.5 --model.sample_rate 0.004 --trainer.max_epochs 1 --data.data_dir runs/mnist/data --data.sample_rate 0.004
+            python -c "import torch; exit(0)"
+          when: always
+      - store_test_results:
+          path: runs/mnist-lightning/test-reports
+      - store_artifacts:
+          path: runs/mnist-lightning/test-reports
+
   cifar10_integration_test:
     description: "Runs CIFAR10 example end to end"
     parameters:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -15,3 +15,4 @@ tensorboard
 datasets
 transformers
 scikit-learn
+pytorch-lightning[extra]

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -15,4 +15,5 @@ tensorboard
 datasets
 transformers
 scikit-learn
-pytorch-lightning[extra]
+pytorch-lightning
+jsonargparse[signatures]>=3.19.3 # required for Lightning CLI

--- a/examples/mnist_lightning.py
+++ b/examples/mnist_lightning.py
@@ -32,19 +32,20 @@ from opacus.utils.uniform_sampler import UniformWithReplacementSampler
 
 
 import warnings
-warnings.filterwarnings('ignore')
+
+warnings.filterwarnings("ignore")
 
 
 class LitSampleConvNetClassifier(pl.LightningModule):
     def __init__(
-            self,
-            lr: float = 0.1,
-            enable_dp: bool = True,
-            delta: float = 1e-5,
-            sample_rate: float = 0.001,
-            sigma: float = 1.0,
-            max_per_sample_grad_norm: float = 1.0,
-            secure_rng: bool = False,
+        self,
+        lr: float = 0.1,
+        enable_dp: bool = True,
+        delta: float = 1e-5,
+        sample_rate: float = 0.001,
+        sigma: float = 1.0,
+        max_per_sample_grad_norm: float = 1.0,
+        secure_rng: bool = False,
     ):
         """A simple conv-net for classifying MNIST with differential privacy
 
@@ -132,17 +133,17 @@ class LitSampleConvNetClassifier(pl.LightningModule):
         loss = F.cross_entropy(output, target)
         self.test_accuracy(output, target)
         self.log("test_loss", loss, on_step=False, on_epoch=True, prog_bar=True)
-        self.log('test_accuracy', self.test_accuracy, on_step=False, on_epoch=True)
+        self.log("test_accuracy", self.test_accuracy, on_step=False, on_epoch=True)
         return loss
 
 
 class MNISTDataModule(pl.LightningDataModule):
     def __init__(
-            self,
-            data_dir: Optional[str] = "../mnist",
-            test_batch_size: int = 1024,
-            sample_rate: float = 0.001,
-            secure_rng: bool = False,
+        self,
+        data_dir: Optional[str] = "../mnist",
+        test_batch_size: int = 1024,
+        sample_rate: float = 0.001,
+        secure_rng: bool = False,
     ):
         """MNIST DataModule with DP-ready batch sampling
 
@@ -190,7 +191,7 @@ class MNISTDataModule(pl.LightningDataModule):
             download=False,
             transform=self.transform,
         )
-        return torch.utils.data.DataLoader(
+        return DataLoader(
             train_dataset,
             batch_sampler=UniformWithReplacementSampler(
                 num_samples=len(train_dataset),
@@ -201,7 +202,7 @@ class MNISTDataModule(pl.LightningDataModule):
         )
 
     def test_dataloader(self):
-        return torch.utils.data.DataLoader(
+        return DataLoader(
             datasets.MNIST(
                 self.data_root,
                 train=False,

--- a/examples/mnist_lightning.py
+++ b/examples/mnist_lightning.py
@@ -139,7 +139,6 @@ class LitSampleConvNetClassifier(pl.LightningModule):
             self.privacy_engine.detach()
 
 
-
 class MNISTDataModule(pl.LightningDataModule):
     def __init__(
         self,

--- a/examples/mnist_lightning.py
+++ b/examples/mnist_lightning.py
@@ -15,22 +15,20 @@ To see logs:
 $ tensorboard --logdir=lightning_logs/
 """
 
+import warnings
 from typing import Optional
 
+import pytorch_lightning as pl
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-from torch.utils.data import DataLoader
-import pytorch_lightning as pl
-from pytorch_lightning.utilities.cli import LightningCLI
-from torchvision import datasets, transforms
 import torchmetrics
-
 from opacus import PrivacyEngine
 from opacus.utils.uniform_sampler import UniformWithReplacementSampler
+from pytorch_lightning.utilities.cli import LightningCLI
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
 
-
-import warnings
 
 warnings.filterwarnings("ignore")
 

--- a/examples/mnist_lightning.py
+++ b/examples/mnist_lightning.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+"""
+Runs MNIST training with differential privacy.
+"""
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from pytorch_lightning.utilities.cli import LightningCLI
+
+from opacus import PrivacyEngine
+from opacus.utils.uniform_sampler import UniformWithReplacementSampler
+from torchvision import datasets, transforms
+import pytorch_lightning as pl
+import torchmetrics
+
+
+class LitSampleConvNet(pl.LightningModule):
+    def __init__(
+            self,
+            lr: float = 0.1,
+            sample_rate: float = 0.001,
+            sigma: float = 1.0,
+            max_per_sample_grad_norm: float = 1.0,
+            delta: float = 1e-5,
+            disable_dp: bool = False,
+            secure_rng: bool = False,
+    ):
+        super().__init__()
+
+        # Hyper-parameters
+        self.lr = lr
+        self.sample_rate = sample_rate
+        self.sigma = sigma
+        self.max_per_sample_grad_norm = max_per_sample_grad_norm
+        self.delta = delta
+        self.disable_dp = disable_dp
+        self.secure_rng = secure_rng
+
+        if secure_rng:
+            try:
+                import torchcsprng as prng
+            except ImportError as e:
+                msg = (
+                    "To use secure RNG, you must install the torchcsprng package! "
+                    "Check out the instructions here: https://github.com/pytorch/csprng#installation"
+                )
+                raise ImportError(msg) from e
+            self.generator = prng.create_random_device_generator("/dev/urandom")
+        else:
+            self.generator = None
+
+        # Parameters
+        self.conv1 = nn.Conv2d(1, 16, 8, 2, padding=3)
+        self.conv2 = nn.Conv2d(16, 32, 4, 2)
+        self.fc1 = nn.Linear(32 * 4 * 4, 32)
+        self.fc2 = nn.Linear(32, 10)
+
+        # Metrics
+        self.test_accuracy = torchmetrics.Accuracy()
+
+    def setup(self, stage=None):
+        if not self.disable_dp:
+            self.privacy_engine = PrivacyEngine(
+                self,
+                sample_rate=self.sample_rate,
+                alphas=[1 + x / 10.0 for x in range(1, 100)] + list(range(12, 64)),
+                noise_multiplier=self.sigma,
+                max_grad_norm=self.max_per_sample_grad_norm,
+                secure_rng=self.secure_rng,
+            )
+
+    def forward(self, x):
+        # x of shape [B, 1, 28, 28]
+        x = F.relu(self.conv1(x))  # -> [B, 16, 14, 14]
+        x = F.max_pool2d(x, 2, 1)  # -> [B, 16, 13, 13]
+        x = F.relu(self.conv2(x))  # -> [B, 32, 5, 5]
+        x = F.max_pool2d(x, 2, 1)  # -> [B, 32, 4, 4]
+        x = x.view(-1, 32 * 4 * 4)  # -> [B, 512]
+        x = F.relu(self.fc1(x))  # -> [B, 32]
+        x = self.fc2(x)  # -> [B, 10]
+        return x
+
+    def configure_optimizers(self):
+        optimizer = optim.SGD(self.parameters(), lr=self.lr, momentum=0)
+        if not self.disable_dp:
+            self.privacy_engine.attach(optimizer)
+        return optimizer
+
+    def training_step(self, batch, batch_idx):
+        data, target = batch
+        output = self(data)
+        loss = F.cross_entropy(output, target)
+        return loss
+
+    def test_step(self, batch, batch_idx):
+        data, target = batch
+        output = self(data)
+        loss = F.cross_entropy(output, target)
+        self.test_accuracy(output, target)
+        self.log('test_accuracy', self.test_accuracy, on_step=False, on_epoch=True)
+        return loss
+
+
+class MNISTDataModule(pl.LightningDataModule):
+    def __init__(
+            self,
+            data_dir: Optional[str] = "../mnist",
+            sample_rate: float = 0.001,
+            test_batch_size: int = 32,
+            secure_rng: bool = False,
+    ):
+        super().__init__()
+        self.data_root = data_dir
+        self.dataloader_kwargs = {"num_workers": 1, "pin_memory": True}
+
+        self.save_hyperparameters()
+
+        if secure_rng:
+            try:
+                import torchcsprng as prng
+            except ImportError as e:
+                msg = (
+                    "To use secure RNG, you must install the torchcsprng package! "
+                    "Check out the instructions here: https://github.com/pytorch/csprng#installation"
+                )
+                raise ImportError(msg) from e
+            self.generator = prng.create_random_device_generator("/dev/urandom")
+        else:
+            self.generator = None
+
+    @property
+    def transform(self):
+        return transforms.Compose(
+            [
+                transforms.ToTensor(),
+                transforms.Normalize((0.1307,), (0.3081,)),
+            ]
+        )
+
+    def prepare_data(self) -> None:
+        datasets.MNIST(self.data_root, download=True)
+
+    def train_dataloader(self):
+        train_dataset = datasets.MNIST(
+            self.data_root,
+            train=True,
+            download=False,
+            transform=self.transform,
+        )
+        return torch.utils.data.DataLoader(
+            train_dataset,
+            batch_sampler=UniformWithReplacementSampler(
+                num_samples=len(train_dataset),
+                sample_rate=self.hparams.sample_rate,
+                generator=self.generator,
+            ),
+            **self.dataloader_kwargs,
+        )
+
+    def test_dataloader(self):
+        return torch.utils.data.DataLoader(
+            datasets.MNIST(
+                self.data_root,
+                train=False,
+                download=False,
+                transform=self.transform,
+            ),
+            batch_size=self.hparams.test_batch_size,
+            shuffle=True,
+            **self.dataloader_kwargs,
+        )
+
+
+def cli_main():
+    cli = LightningCLI(
+        LitSampleConvNet,
+        MNISTDataModule,
+    )
+    cli.trainer.fit(cli.model, datamodule=cli.datamodule)
+    cli.trainer.test(ckpt_path="best", datamodule=cli.datamodule)
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/examples/mnist_lightning.py
+++ b/examples/mnist_lightning.py
@@ -10,7 +10,6 @@ $ python mnist_lightning.py fit
 
 To see logs:
 $ tensorboard --logdir=lightning_logs/
-
 """
 
 from typing import Optional
@@ -33,7 +32,7 @@ import warnings
 warnings.filterwarnings('ignore')
 
 
-class LitSampleConvNet(pl.LightningModule):
+class LitSampleConvNetClassifier(pl.LightningModule):
     def __init__(
             self,
             lr: float = 0.1,
@@ -42,7 +41,6 @@ class LitSampleConvNet(pl.LightningModule):
             max_per_sample_grad_norm: float = 1.0,
             delta: float = 1e-5,
             enable_dp: bool = True,
-            secure_rng: bool = False,
     ):
         super().__init__()
 
@@ -53,20 +51,6 @@ class LitSampleConvNet(pl.LightningModule):
         self.max_per_sample_grad_norm = max_per_sample_grad_norm
         self.delta = delta
         self.enable_dp = enable_dp
-        self.secure_rng = secure_rng
-
-        if secure_rng:
-            try:
-                import torchcsprng as prng
-            except ImportError as e:
-                msg = (
-                    "To use secure RNG, you must install the torchcsprng package! "
-                    "Check out the instructions here: https://github.com/pytorch/csprng#installation"
-                )
-                raise ImportError(msg) from e
-            self.generator = prng.create_random_device_generator("/dev/urandom")
-        else:
-            self.generator = None
 
         # Parameters
         self.conv1 = nn.Conv2d(1, 16, 8, 2, padding=3)
@@ -216,7 +200,7 @@ class MNISTDataModule(pl.LightningDataModule):
 
 def cli_main():
     cli = LightningCLI(
-        LitSampleConvNet,
+        LitSampleConvNetClassifier,
         MNISTDataModule,
         save_config_overwrite=True,
         trainer_defaults={

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -352,6 +352,8 @@ class PrivacyEngine:
                 self.privacy_engine.steps += 1
                 return self.original_step(closure)
             else:
+                # Before running privacy_engine.step() we need to reevaluate the model and run backward() to compute
+                # grad_sample. In case these steps are provided in a closure, we need to run it.
                 loss = None
                 if closure is not None:
                     with torch.enable_grad():

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -350,15 +350,22 @@ class PrivacyEngine:
             if hasattr(self.privacy_engine.module, "ddp_hooks"):
                 # We just update the accountant
                 self.privacy_engine.steps += 1
-
+                return self.original_step(closure)
             else:
+                loss = None
+                if closure is not None:
+                    with torch.enable_grad():
+                        loss = closure()
+
                 self.privacy_engine.step(is_empty)
                 if isinstance(
                     self.privacy_engine.module._module,
                     DifferentiallyPrivateDistributedDataParallel,
                 ):
                     average_gradients(self.privacy_engine.module)
-            self.original_step(closure)
+
+                self.original_step()
+                return loss
 
         def poisson_dp_step(self, closure=None):
             # Perform one step as usual
@@ -483,6 +490,7 @@ class PrivacyEngine:
 
         """
         self.steps += 1
+
         if not is_empty:
             self.clipper.clip_and_accumulate()
             clip_values, batch_size = self.clipper.pre_step()


### PR DESCRIPTION
## Opacus + Lightning

[PyTorch Lightning](https://www.pytorchlightning.ai/) is one of the most used frameworks for PyTorch. It helps to remove boilerplate code, improve readability and reproducibility. Lightning does this by restructuring the code (and not changing), uses core PyTorch objects without wrapping them.

We want:
1. Provide PL users with a way to use Opacus
2. Adapt our API to add privacy learning with minumin changes (ideally with no changes) to LightningModule

## Proposed Changes

**Example** `mnist_lightning.py`. 
Demonstration of how to add privacy-preserving learning to PL-based code. This is a clone of `mnist.py` written with PL. The code is self-descriptive and uses [best practices](https://pytorch-lightning.readthedocs.io/en/latest/starter/style_guide.html).

**Fixed** important bug in DPOptimizer causing #147. 
The fix makes the example workable. Optimizer closure was used incorrectly in `dp_step()`: the model is not reevaluated before making a DP-step, as the result we don't have grad_samples to make a step. I believe this can affect training not only in the Lightning scenario.

_This is for the main branch, not v1.0._ 
Merging this change with v1.0 is straightforward, but we need to disassemble `make_private()` into parts. The code won't be the most elegant, but this approach is transparent and easy to debug/undestand.

## New API and Full Integration with Lightning

Creating a seamless integration is a challenging task:
- Opacus requires dependencies between model, optimizer and dataloader. Whereas Lightning forces separation between them.
- From Ligthning's perspective, Opacus implements a custom [`pl.Trainer`](https://pytorch-lightning.readthedocs.io/en/latest/common/trainer.html) flow. `Trainer` is not designed to be extended through inheritance. 
  - A custom Trainer could be a straightforward solution for user, but it works only in short-term and very hard to maintain. 
- `Trainer` promotes using [callbacks](https://pytorch-lightning.readthedocs.io/en/latest/extensions/callbacks.html) and [custom loops](https://pytorch-lightning.readthedocs.io/en/latest/extensions/loops.html) for extension. This seems to me the only viable way to integrate. In this case `Trainer` will need to either 
  1. mutate modules (attach and detach privacy-related stuff)
  2. check and accept only valid modules, check that LightningModule and DataModule is properly tied, throw exception otherwise

I will follow up with some options.

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
