### PR TITLE
Enable validation for GradSampleModule

### DIFF
--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -338,7 +338,7 @@ class BasePrivacyEngineTest(ABC):
         noise_multiplier=st.floats(0.5, 5.0),
         max_steps=st.integers(8, 10),
     )
-    @settings(max_examples=20, deadline=20000)
+    @settings(max_examples=20, deadline=None)
     def test_noise_level(self, noise_multiplier: float, max_steps: int):
         """
         Tests that the noise level is correctly set


### PR DESCRIPTION
## Substantial changes

1) GradSampleModule now checks the input module for compatible modules.
Motivation: if using `GradSampleModule` outside `PrivacyEngine`, we want to signal to the user is their module contains unsupported or incompatible modules. The impact of not doing so would be either unexpectedly missing `grad_samples` on some parameters (remember, the user might not know the exact list of supported modules) or wrong results altogether (if there's something like `BatchNorm` is involved)

2) We switch to simple model for `grad_sample_module_test.py`. The reason is `mobilenet_v3_small` actually contains `BatchNorm` and don't pass validation 
