### PR TITLE
address TODOs, part 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,13 +74,6 @@ commands:
           name: "Check import order with isort"
           command: isort -v -l 88 -o opacus --lines-after-imports 2 -m 3 --trailing-comma --check-only .
 
-  mypy_check:
-    description: "Static type checking with mypy"
-    steps:
-      - run:
-          name: "Mypy checks"
-          command: ./scripts/run_mypy.sh
-
   configure_docusaurus_bot:
     description: "Configure Docusaurus GitHub bot"
     steps:
@@ -251,7 +244,6 @@ jobs:
       - lint_flake8
       - lint_black
       - isort
-      # - mypy_check  TODO re-enable
 
   unittest_py37_torch_release:
     docker:

--- a/opacus/accountants/gdp.py
+++ b/opacus/accountants/gdp.py
@@ -27,8 +27,7 @@ class GaussianAccountant(IAccountant):
                 self.steps, self.noise_multiplier, self.sample_rate, delta
             )
         else:
-            # TODO: this should be different from the call above
-            epsilon = privacy_analysis.compute_eps_poisson(
+            epsilon = privacy_analysis.compute_eps_uniform(
                 self.steps, self.noise_multiplier, self.sample_rate, delta
             )
 

--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -37,8 +37,6 @@ def _generate_noise(
     std: float, reference: torch.Tensor, generator=None
 ) -> torch.Tensor:
     if std > 0:
-        # TODO: handle device transfers: generator and reference tensor
-        # could be on different devices
         return torch.normal(
             mean=0,
             std=std,
@@ -93,6 +91,9 @@ class DPOptimizer(Optimizer):
         self.state = optimizer.state
         self._step_skip_queue = []
         self._is_last_step_skipped = False
+
+        for p in self.params:
+            p.summed_grad = None
 
     def signal_skip_step(self, do_skip=True):
         self._step_skip_queue.append(do_skip)
@@ -153,7 +154,7 @@ class DPOptimizer(Optimizer):
             grad_sample = _get_flat_grad_sample(p)
             grad = torch.einsum("i,i...", per_sample_clip_factor, grad_sample)
 
-            if hasattr(p, "summed_grad"):
+            if p.summed_grad is not None:
                 p.summed_grad += grad
             else:
                 p.summed_grad = grad
@@ -180,11 +181,10 @@ class DPOptimizer(Optimizer):
 
     def zero_grad(self, set_to_none: bool = False):
         for p in self.params:
-            if hasattr(p, "grad_sample"):
-                del p.grad_sample
+            p.grad_sample = None
 
-            if hasattr(p, "summed_grad") and not self._is_last_step_skipped:
-                del p.summed_grad
+            if not self._is_last_step_skipped:
+                p.summed_grad = None
 
         self.original_optimizer.zero_grad(set_to_none)
 
@@ -212,4 +212,11 @@ class DPOptimizer(Optimizer):
         else:
             return None
 
-    # TODO: wrap the rest of optim.Optimizer interface
+    def __repr__(self):
+        return self.original_optimizer.__repr__()
+
+    def state_dict(self):
+        return self.original_optimizer.state_dict()
+
+    def load_state_dict(self, state_dict) -> None:
+        self.original_optimizer.load_state_dict(state_dict)

--- a/opacus/optimizers/perlayeroptimizer.py
+++ b/opacus/optimizers/perlayeroptimizer.py
@@ -42,7 +42,7 @@ class DPPerLayerOptimizer(DPOptimizer):
             )
             grad = torch.einsum("i,i...", per_sample_clip_factor, p.grad_sample)
 
-            if hasattr(p, "summed_grad"):
+            if p.summed_grad is not None:
                 p.summed_grad += grad
             else:
                 p.summed_grad = grad

--- a/opacus/tests/grad_sample_module_test.py
+++ b/opacus/tests/grad_sample_module_test.py
@@ -38,7 +38,7 @@ class SampleConvNet(nn.Module):
         return "SampleConvNet"
 
 
-class GradSampleModule_test(unittest.TestCase):
+class GradSampleModuleTest(unittest.TestCase):
     def setUp(self):
         self.original_model = SampleConvNet()
         copy_of_original_model = SampleConvNet()
@@ -75,7 +75,6 @@ class GradSampleModule_test(unittest.TestCase):
         Gradients are tested in the various `grad_samples` tests.
         """
         x, _ = next(iter(self.dl))
-        print(f"SHAPE: {x.shape}")
         self.original_model = self.original_model.eval()
         self.grad_sample_module = self.grad_sample_module.eval()
         with torch.no_grad():
@@ -91,7 +90,6 @@ class GradSampleModule_test(unittest.TestCase):
 
     def test_zero_grad(self):
         x, _ = next(iter(self.dl))
-        print(f"SHAPE: {x.shape}")
         self.original_model = self.original_model.train()
         self.grad_sample_module = self.grad_sample_module.train()
         gs_out = self.grad_sample_module(x)
@@ -102,7 +100,7 @@ class GradSampleModule_test(unittest.TestCase):
         params_with_gs = [
             n
             for n, p in self.grad_sample_module.named_parameters()
-            if hasattr(p, "grad_sample")
+            if p.grad_sample is not None
         ]
         msg = (
             "After calling .zero_grad() on the GradSampleModule, the following parameters still "
@@ -210,3 +208,10 @@ class GradSampleModule_test(unittest.TestCase):
 
         # Should not raise exception if strict=False
         GradSampleModule(mobilenet_v3_small(), strict=False)
+
+    def test_submodule_access(self):
+        _ = self.grad_sample_module.fc1
+        _ = self.grad_sample_module.fc2
+
+        with self.assertRaises(AttributeError):
+            _ = self.grad_sample_module.fc3

--- a/opacus/tests/randomness_test.py
+++ b/opacus/tests/randomness_test.py
@@ -241,6 +241,15 @@ class OptimizerRandomnessTest(unittest.TestCase):
         self.assertTrue(torch.allclose(model1._module.weight, model2._module.weight))
 
 
+def _init_generator(seed: Optional[int] = None):
+    if seed:
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+        return generator
+
+    return None
+
+
 class PrivacyEngineSecureModeTest(unittest.TestCase):
     def setUp(self) -> None:
         self.data = torch.randn(80, 32)
@@ -266,10 +275,8 @@ class PrivacyEngineSecureModeTest(unittest.TestCase):
         noise: float = 1.0,
         poisson_sampling: bool = True,
     ):
-        dl_generator = None
-        if dl_seed:
-            dl_generator = torch.Generator()
-            dl_generator.manual_seed(dl_seed)
+        dl_generator = _init_generator(dl_seed)
+        noise_generator = _init_generator(noise_seed)
 
         model, optim, dl = self._init_training(dl_generator=dl_generator)
         privacy_engine = PrivacyEngine(secure_mode=secure_mode)
@@ -280,7 +287,7 @@ class PrivacyEngineSecureModeTest(unittest.TestCase):
             data_loader=dl,
             noise_multiplier=noise,
             max_grad_norm=1.0,
-            noise_seed=noise_seed,
+            noise_generator=noise_generator,
             poisson_sampling=poisson_sampling,
         )
 


### PR DESCRIPTION
Second and final part of addressing TODOs in the codebase. What's left there can be fixed later.

### More changes to `zero_grad`

We're bringing the empty grad behaviour closer to PyTorch.
Currently if you have empty gradients, `p.grad` would be either None or tensor of zeros, while `p.grad_sample` would throw an `AttributeError`.
With this change we add `grad_sample` attribute to all `GradSampleModule` parameters, setting it to None initially.

We still can't support setting empty grads to tensor of 0s, because accumulation rules are different between regular grads and per-sample grads.

### Noise_seed -> Noise generator

As I found out, there's no (easy?) way to move an existing `torch.Generator` between devices. 
So we'd have to let clients deal with it. Current implementation doesn't let client provide a device with which to initialize Generator. So instead we'd ask them to provide generator iteself

### Other

- Removed reference to mypy. We've had a todo item to bring it back, but since then we're increasingly rely on monkeypatching, so I don't think we'll be able ti bring it back any time soon
- GDP accountant: we've had a no-op if-else branch. cc @alexandresablayrolles to check if changes to `gdp.py` make sense
- Wrapped couple more methods from `torch.optim.Optimizer` for `DPOptimizer`. Didn't test whether it works, but looks ok