### PR TITLE
[RFC] Add debug mode

### DIFF
--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -97,6 +97,7 @@ class DPOptimizer(Optimizer):
         loss_reduction: str = "mean",
         generator=None,
         secure_mode=False,
+        debug=False,
     ):
         if loss_reduction not in ("mean", "sum"):
             raise ValueError(f"Unexpected value for loss_reduction: {loss_reduction}")
@@ -114,6 +115,9 @@ class DPOptimizer(Optimizer):
         self.step_hook = None
         self.generator = generator
         self.secure_mode = secure_mode
+        self.debug = debug
+        if debug:
+            self.grad_norms = []
 
         self.param_groups = optimizer.param_groups
         self.state = optimizer.state
@@ -172,6 +176,8 @@ class DPOptimizer(Optimizer):
         per_sample_clip_factor = (self.max_grad_norm / (per_sample_norms + 1e-6)).clamp(
             max=1.0
         )
+        if self.debug:
+            self.grad_norms += per_sample_norms.tolist()
 
         for p in self.params:
             grad_sample = _get_flat_grad_sample(p)

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -29,7 +29,7 @@ def forbid_accumulation_hook(module: nn.Module, _):
 
 
 class PrivacyEngine:
-    def __init__(self, accountant: str = "rdp", secure_mode=False):
+    def __init__(self, accountant: str = "rdp", secure_mode=False, debug=False):
         """
         # TODO: Add docstring with doctest
         # - Creating PrivacyEngine and applying make_private (test_privacy_engine_class_example)
@@ -54,6 +54,7 @@ class PrivacyEngine:
         """
         self.accountant = get_accountant(mechanism=accountant)
         self.secure_mode = secure_mode
+        self.debug = debug
         self.secure_rng = None
 
         if self.secure_mode:
@@ -107,6 +108,7 @@ class PrivacyEngine:
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=self.secure_mode,
+            debug=self.debug,
         )
 
     def _prepare_data_loader(


### PR DESCRIPTION
This is an RFC for a "debug mode" for Opacus. 
Often when using DP, things do not work as expected and it can be useful to have access to some lower-level signals. In particular, gradient norms are computed by the DPOptimizer but are then "thrown away".
The idea of the debug mode is to typically log this information to make it accessible to the user.