### PR TITLE
require python 3.7 + minor refactoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,15 @@ version: 2.1
 commands:
 
   py_3_7_setup:
-    description: "Install and switch to Python 3.7.10; also install pip and pytest."
+    description: "Install and switch to Python 3.7.4; also install pip and pytest."
     steps:
       - run:
-          name: "Setup Python v3.7.10 environment"
+          name: "Setup Python v3.7.4 environment"
           command: |
             cd /opt/circleci/.pyenv && git pull && cd -
-            pyenv install -s 3.7.10
-            pyenv global 3.7.10
-            pyenv local 3.7.10
+            pyenv install -s 3.7.4
+            pyenv global 3.7.4
+            pyenv local 3.7.4
             pyenv versions
             echo "In venv: $(pyenv local) - $(python -V), $(pip -V)"
             sudo "$(which python)" -m pip install --upgrade pip
@@ -259,7 +259,7 @@ jobs:
 
   lint_py37_torch_release:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.7.4
     steps:
       - checkout
       - pip_dev_install
@@ -269,7 +269,7 @@ jobs:
 
   unittest_py37_torch_release:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.7.4
     steps:
       - checkout
       - pip_dev_install
@@ -302,7 +302,7 @@ jobs:
 
   integrationtest_py37_torch_release_cpu:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.7.4
     steps:
       - checkout
       - pip_dev_install

--- a/opacus/accountants/accountant.py
+++ b/opacus/accountants/accountant.py
@@ -1,5 +1,6 @@
 import abc
-
+from opacus.optimizers import DPOptimizer
+from typing import Callable
 
 class IAccountant(abc.ABC):
     @abc.abstractmethod
@@ -22,3 +23,14 @@ class IAccountant(abc.ABC):
     @abc.abstractmethod
     def mechanism(cls) -> str:
         pass
+
+    def get_optimizer_hook_fn(self, sample_rate: float) -> Callable[[DPOptimizer], None]:
+        def hook_fn(optim: DPOptimizer):
+            # This works for Poisson for both single-node and distributed
+            # The reason is that the sample rate is the same in both cases (but in
+            # distributed mode, each node samples among a subset of the data)
+            self.step(
+                noise_multiplier=optim.noise_multiplier,
+                sample_rate=sample_rate * optim.accumulated_iterations,
+            )
+        return hook_fn

--- a/opacus/accountants/accountant.py
+++ b/opacus/accountants/accountant.py
@@ -1,6 +1,8 @@
 import abc
-from opacus.optimizers import DPOptimizer
 from typing import Callable
+
+from opacus.optimizers import DPOptimizer
+
 
 class IAccountant(abc.ABC):
     @abc.abstractmethod
@@ -24,7 +26,9 @@ class IAccountant(abc.ABC):
     def mechanism(cls) -> str:
         pass
 
-    def get_optimizer_hook_fn(self, sample_rate: float) -> Callable[[DPOptimizer], None]:
+    def get_optimizer_hook_fn(
+        self, sample_rate: float
+    ) -> Callable[[DPOptimizer], None]:
         def hook_fn(optim: DPOptimizer):
             # This works for Poisson for both single-node and distributed
             # The reason is that the sample rate is the same in both cases (but in
@@ -33,4 +37,5 @@ class IAccountant(abc.ABC):
                 noise_multiplier=optim.noise_multiplier,
                 sample_rate=sample_rate * optim.accumulated_iterations,
             )
+
         return hook_fn

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -346,16 +346,7 @@ class PrivacyEngine:
             clipping=clipping,
         )
 
-        def accountant_hook(optim: DPOptimizer):
-            # This works for Poisson for both single-node and distributed
-            # The reason is that the sample rate is the same in both cases (but in
-            # distributed mode, each node samples among a subset of the data)
-            self.accountant.step(
-                noise_multiplier=optim.noise_multiplier,
-                sample_rate=sample_rate * optim.accumulated_iterations,
-            )
-
-        optimizer.attach_step_hook(accountant_hook)
+        optimizer.attach_step_hook(self.accountant.get_optimizer_hook_fn(sample_rate=sample_rate))
 
         return module, optimizer, data_loader
 

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -346,7 +346,9 @@ class PrivacyEngine:
             clipping=clipping,
         )
 
-        optimizer.attach_step_hook(self.accountant.get_optimizer_hook_fn(sample_rate=sample_rate))
+        optimizer.attach_step_hook(
+            self.accountant.get_optimizer_hook_fn(sample_rate=sample_rate)
+        )
 
         return module, optimizer, data_loader
 

--- a/setup.py
+++ b/setup.py
@@ -77,5 +77,5 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering",
     ],
-    python_requires=f">={REQUIRED_MAJOR}.{REQUIRED_MINOR}.{REQUIRED_MICRO}",
+    python_requires=f">={REQUIRED_MAJOR}.{REQUIRED_MINOR}",
 )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from setuptools import find_packages, setup
 
 REQUIRED_MAJOR = 3
 REQUIRED_MINOR = 7
+REQUIRED_MICRO = 4
 
 version = {}
 with open("opacus/version.py") as fp:
@@ -17,16 +18,17 @@ with open("opacus/version.py") as fp:
 __version__ = version["__version__"]
 
 # Check for python version
-if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
+if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR, REQUIRED_MICRO):
     error = (
         "Your version of python ({major}.{minor}.{micro}) is too old. You need "
-        "python >= {required_major}.{required_minor}"
+        "python >= {required_major}.{required_minor}.{required_micro}"
     ).format(
         major=sys.version_info.major,
         minor=sys.version_info.minor,
         micro=sys.version_info.micro,
         required_major=REQUIRED_MAJOR,
         required_minor=REQUIRED_MINOR,
+        required_micro=REQUIRED_MICRO,
     )
     sys.exit(error)
 
@@ -77,5 +79,5 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Scientific/Engineering",
     ],
-    python_requires=f">={REQUIRED_MAJOR}.{REQUIRED_MINOR}",
+    python_requires=f">={REQUIRED_MAJOR}.{REQUIRED_MINOR}.{REQUIRED_MICRO}",
 )

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,8 @@ import sys
 from setuptools import find_packages, setup
 
 
-# 3.6.8 is the final Windows binary release for 3.6.x
 REQUIRED_MAJOR = 3
-REQUIRED_MINOR = 6
-REQUIRED_MICRO = 8
-
+REQUIRED_MINOR = 7
 
 version = {}
 with open("opacus/version.py") as fp:
@@ -20,17 +17,16 @@ with open("opacus/version.py") as fp:
 __version__ = version["__version__"]
 
 # Check for python version
-if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR, REQUIRED_MICRO):
+if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
     error = (
         "Your version of python ({major}.{minor}.{micro}) is too old. You need "
-        "python >= {required_major}.{required_minor}.{required_micro}"
+        "python >= {required_major}.{required_minor}"
     ).format(
         major=sys.version_info.major,
         minor=sys.version_info.minor,
         micro=sys.version_info.micro,
         required_major=REQUIRED_MAJOR,
         required_minor=REQUIRED_MINOR,
-        required_micro=REQUIRED_MICRO,
     )
     sys.exit(error)
 


### PR DESCRIPTION
Following some internal test failures on #273, we've decided to up min required python version (we use annotations from __future__, which are only introduced in 3.7). Since 3.7 is already a default in colab, and is pretty popular overall, I don't see many potential issues with it.

One more change (which probably should have been decoupled into a separate pull request) is accountant hook refactoring. While writing guide on advanced usage of opacus, I realised that accountant hook is always the same for a given accountant. It can be different for different accountants, but same mechanism always requires the same hook. 

This change makes it easier to attach accountant outside of PrivacyEngine