### PR TITLE
rename raise_if_error mode to strict mode in validator

### DIFF
--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -73,7 +73,7 @@ class GradSampleModule(nn.Module):
     ):
         super().__init__()
 
-        errors = self.validate(module=m, raise_if_error=strict)
+        errors = self.validate(module=m, strict=strict)
         if errors and not strict:
             logger.info(
                 f"GradSampleModule found the following errors: {errors}."
@@ -361,7 +361,7 @@ class GradSampleModule(nn.Module):
 
     @classmethod
     def validate(
-        cls, module: nn.Module, raise_if_error: bool = False
+        cls, module: nn.Module, strict: bool = False
     ) -> List[NotImplementedError]:
         """Validate support for module being wrapped"""
         errors = []
@@ -373,7 +373,7 @@ class GradSampleModule(nn.Module):
             ]
         )
         # raise or return errors as needed
-        if raise_if_error and len(errors) > 0:
+        if strict and len(errors) > 0:
             raise NotImplementedError(errors)
         else:
             return errors

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -227,7 +227,7 @@ class PrivacyEngine:
             UnsupportedModuleError
                 If one or more modules found to be incompatible
         """
-        ModuleValidator.validate(module, raise_if_error=True)
+        ModuleValidator.validate(module, strict=True)
 
     @classmethod
     def get_compatible_module(cls, module: nn.Module) -> nn.Module:
@@ -245,7 +245,7 @@ class PrivacyEngine:
             more details
         """
         module = ModuleValidator.fix(module)
-        ModuleValidator.validate(module, raise_if_error=True)
+        ModuleValidator.validate(module, strict=True)
         return module
 
     def make_private(

--- a/opacus/tests/module_validator_test.py
+++ b/opacus/tests/module_validator_test.py
@@ -20,7 +20,7 @@ class ModuleValidator_test(unittest.TestCase):
 
     def test_validate_invalid_model(self):
         with self.assertRaises(UnsupportedModuleError):
-            ModuleValidator.validate(self.original_model, raise_if_error=True)
+            ModuleValidator.validate(self.original_model, strict=True)
         errors = ModuleValidator.validate(self.original_model)
         self.assertGreater(len(errors), 0)
 

--- a/opacus/validators/module_validator.py
+++ b/opacus/validators/module_validator.py
@@ -34,15 +34,15 @@ class ModuleValidator:
 
     @classmethod
     def validate(
-        cls, module: nn.Module, raise_if_error: bool = False
+        cls, module: nn.Module, strict: bool = False
     ) -> List[UnsupportedModuleError]:
         """
         Validate module and sub_modules by running registered custom validators.
-        Returns or raises excpetions depending on ``raise_if_error`` flag.
+        Returns or raises excpetions depending on ``strict`` flag.
 
         Args:
             module: The root module to validate.
-            raise_if_error: Boolean to indicate whether to raise errors or return
+            strict: Boolean to indicate whether to raise errors or return
             the list of errors.
 
         Raises:
@@ -55,14 +55,14 @@ class ModuleValidator:
                 IllegalModuleConfigurationError("Model needs to be in training mode")
             )
         # 2. validate that all trainable modules are supported by GradSampleModule.
-        errors.extend(GradSampleModule.validate(module=module, raise_if_error=False))
+        errors.extend(GradSampleModule.validate(module=module, strict=False))
         # 3. perform module specific validations.
         for _, sub_module in module.named_modules():
             if type(sub_module) in ModuleValidator.VALIDATORS:
                 sub_module_validator = ModuleValidator.VALIDATORS[type(sub_module)]
                 errors.extend(sub_module_validator(sub_module))
         # raise/return as needed
-        if raise_if_error and len(errors) > 0:
+        if strict and len(errors) > 0:
             raise UnsupportedModuleError(errors)
         else:
             return errors
@@ -78,7 +78,7 @@ class ModuleValidator:
         Returns:
             bool
         """
-        return len(cls.validate(module, raise_if_error=False)) == 0
+        return len(cls.validate(module, strict=False)) == 0
 
     @classmethod
     def fix(cls, module: nn.Module) -> nn.Module:
@@ -154,6 +154,6 @@ class ModuleValidator:
         # 1. replace any fixable modules
         fixed_module = cls.fix(module)
         # 2. perform module specific validations.
-        cls.validate(fixed_module, raise_if_error=True)
+        cls.validate(fixed_module, strict=True)
         # return fixed module
         return fixed_module


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue
Grad sample module validator throws error on validation failure in strict mode. This naming is concise and to sufficiently elaborate. Changing the arg name in module validator to this to maintain consistency.

## How Has This Been Tested (if it applies)
Circle CI tests

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
