### PR TITLE
PEP 3102 compliance for most Opacus APIs

### DIFF
--- a/examples/cifar10.py
+++ b/examples/cifar10.py
@@ -154,7 +154,7 @@ def train(args, model, train_loader, optimizer, privacy_engine, epoch, device):
         if i % args.print_freq == 0:
             if not args.disable_dp:
                 epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(
-                    args.delta,
+                    delta=args.delta,
                     alphas=[1 + x / 10.0 for x in range(1, 100)] + list(range(12, 64)),
                 )
                 print(

--- a/examples/dcgan.py
+++ b/examples/dcgan.py
@@ -321,7 +321,7 @@ for epoch in range(opt.epochs):
         )
 
         if not opt.disable_dp:
-            epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(opt.delta)
+            epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(delta=opt.delta)
             print(
                 "(ε = %.2f, δ = %.2f) for α = %.2f" % (epsilon, opt.delta, best_alpha)
             )

--- a/examples/dcgan.py
+++ b/examples/dcgan.py
@@ -321,7 +321,9 @@ for epoch in range(opt.epochs):
         )
 
         if not opt.disable_dp:
-            epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(delta=opt.delta)
+            epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(
+                delta=opt.delta
+            )
             print(
                 "(ε = %.2f, δ = %.2f) for α = %.2f" % (epsilon, opt.delta, best_alpha)
             )

--- a/examples/imdb.py
+++ b/examples/imdb.py
@@ -83,7 +83,7 @@ def train(args, model, train_loader, optimizer, privacy_engine, epoch):
         accuracies.append(acc.item())
 
     if not args.disable_dp:
-        epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(args.delta)
+        epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(delta=args.delta)
         print(
             f"Train Epoch: {epoch} \t"
             f"Train Loss: {np.mean(losses):.6f} "

--- a/examples/imdb.py
+++ b/examples/imdb.py
@@ -83,7 +83,9 @@ def train(args, model, train_loader, optimizer, privacy_engine, epoch):
         accuracies.append(acc.item())
 
     if not args.disable_dp:
-        epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(delta=args.delta)
+        epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(
+            delta=args.delta
+        )
         print(
             f"Train Epoch: {epoch} \t"
             f"Train Loss: {np.mean(losses):.6f} "

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -60,7 +60,9 @@ def train(args, model, device, train_loader, optimizer, privacy_engine, epoch):
         losses.append(loss.item())
 
     if not args.disable_dp:
-        epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(delta=args.delta)
+        epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(
+            delta=args.delta
+        )
         print(
             f"Train Epoch: {epoch} \t"
             f"Loss: {np.mean(losses):.6f} "

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -60,7 +60,7 @@ def train(args, model, device, train_loader, optimizer, privacy_engine, epoch):
         losses.append(loss.item())
 
     if not args.disable_dp:
-        epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(args.delta)
+        epsilon, best_alpha = privacy_engine.accountant.get_privacy_spent(delta=args.delta)
         print(
             f"Train Epoch: {epoch} \t"
             f"Loss: {np.mean(losses):.6f} "

--- a/examples/vision_benchmark.py
+++ b/examples/vision_benchmark.py
@@ -105,9 +105,9 @@ def main():  # noqa: C901
             secure_mode=args.secure_mode,
         )
         model, optimizer, train_loader = privacy_engine.make_private(
-            model,
-            optimizer,
-            train_loader,
+            module=model,
+            optimizer=optimizer,
+            data_loader=train_loader,
             noise_multiplier=args.sigma,
             max_grad_norm=max_grad_norm,
             poisson_sampling=False,

--- a/opacus/accountants/accountant.py
+++ b/opacus/accountants/accountant.py
@@ -7,7 +7,7 @@ class IAccountant(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def step(self, noise_multiplier: float, sample_rate: float):
+    def step(self, *, noise_multiplier: float, sample_rate: float):
         pass
 
     @abc.abstractmethod

--- a/opacus/accountants/analysis/gdp.py
+++ b/opacus/accountants/analysis/gdp.py
@@ -16,7 +16,7 @@ from scipy import optimize
 from scipy.stats import norm
 
 
-def compute_mu_uniform(steps, noise_multi, sample_rate):
+def compute_mu_uniform(*, steps, noise_multiplier, sample_rate):
     """Compute mu from uniform subsampling."""
 
     c = sample_rate * np.sqrt(steps)
@@ -24,41 +24,51 @@ def compute_mu_uniform(steps, noise_multi, sample_rate):
         np.sqrt(2)
         * c
         * np.sqrt(
-            np.exp(noise_multi ** (-2)) * norm.cdf(1.5 / noise_multi)
-            + 3 * norm.cdf(-0.5 / noise_multi)
+            np.exp(noise_multiplier ** (-2)) * norm.cdf(1.5 / noise_multiplier)
+            + 3 * norm.cdf(-0.5 / noise_multiplier)
             - 2
         )
     )
 
 
-def compute_mu_poisson(steps, noise_multi, sample_rate):
+def compute_mu_poisson(*, steps, noise_multiplier, sample_rate):
     """Compute mu from Poisson subsampling."""
 
-    return np.sqrt(np.exp(noise_multi ** (-2)) - 1) * np.sqrt(steps) * sample_rate
+    return np.sqrt(np.exp(noise_multiplier ** (-2)) - 1) * np.sqrt(steps) * sample_rate
 
 
-def delta_eps_mu(eps, mu):
+def delta_eps_mu(*, eps, mu):
     """Compute dual between mu-GDP and (epsilon, delta)-DP."""
     return norm.cdf(-eps / mu + mu / 2) - np.exp(eps) * norm.cdf(-eps / mu - mu / 2)
 
 
-def eps_from_mu(mu, delta):
+def eps_from_mu(*, mu, delta):
     """Compute epsilon from mu given delta via inverse dual."""
 
     def f(x):
         """Reversely solve dual by matching delta."""
-        return delta_eps_mu(x, mu) - delta
+        return delta_eps_mu(eps=x, mu=mu) - delta
 
     return optimize.root_scalar(f, bracket=[0, 500], method="brentq").root
 
 
-def compute_eps_uniform(steps, noise_multi, sample_rate, delta):
+def compute_eps_uniform(*, steps, noise_multiplier, sample_rate, delta):
     """Compute epsilon given delta from inverse dual of uniform subsampling."""
 
-    return eps_from_mu(compute_mu_uniform(steps, noise_multi, sample_rate), delta)
+    return eps_from_mu(
+        mu=compute_mu_uniform(
+            steps=steps, noise_multiplier=noise_multiplier, sample_rate=sample_rate
+        ),
+        delta=delta,
+    )
 
 
-def compute_eps_poisson(steps, noise_multi, sample_rate, delta):
+def compute_eps_poisson(*, steps, noise_multiplier, sample_rate, delta):
     """Compute epsilon given delta from inverse dual of Poisson subsampling."""
 
-    return eps_from_mu(compute_mu_poisson(steps, noise_multi, sample_rate), delta)
+    return eps_from_mu(
+        mu=compute_mu_poisson(
+            steps=steps, noise_multiplier=noise_multiplier, sample_rate=sample_rate
+        ),
+        delta=delta,
+    )

--- a/opacus/accountants/analysis/rdp.py
+++ b/opacus/accountants/analysis/rdp.py
@@ -248,7 +248,7 @@ def _compute_rdp(q: float, sigma: float, alpha: float) -> float:
 
 
 def compute_rdp(
-    q: float, noise_multiplier: float, steps: int, orders: Union[List[float], float]
+    *, q: float, noise_multiplier: float, steps: int, orders: Union[List[float], float]
 ) -> Union[List[float], float]:
     r"""Computes Renyi Differential Privacy (RDP) guarantees of the
     Sampled Gaussian Mechanism (SGM) iterated ``steps`` times.
@@ -275,7 +275,7 @@ def compute_rdp(
 
 
 def get_privacy_spent(
-    orders: Union[List[float], float], rdp: Union[List[float], float], delta: float
+    *, orders: Union[List[float], float], rdp: Union[List[float], float], delta: float
 ) -> Tuple[float, float]:
     r"""Computes epsilon given a list of Renyi Differential Privacy (RDP) values at
     multiple RDP orders and target ``delta``.

--- a/opacus/accountants/analysis/rdp.py
+++ b/opacus/accountants/analysis/rdp.py
@@ -26,7 +26,7 @@ Example:
     >>> for q, sigma, steps in parameters:
     ...     rdp += compute_rdp(q=q, noise_multiplier=sigma, steps=steps, orders=orders)
 
-    >>> epsilon, opt_order = get_privacy_spent(orders, rdp, delta=1e-5)
+    >>> epsilon, opt_order = get_privacy_spent(orders=orders, rdp=rdp, delta=1e-5)
     >>> epsilon, opt_order  # doctest: +NUMBER
     (0.336, 23)
 

--- a/opacus/accountants/analysis/rdp.py
+++ b/opacus/accountants/analysis/rdp.py
@@ -24,7 +24,7 @@ Example:
     >>> orders = range(2, max_order + 1)
     >>> rdp = np.zeros_like(orders, dtype=float)
     >>> for q, sigma, steps in parameters:
-    ...     rdp += compute_rdp(q, sigma, steps, orders)
+    ...     rdp += compute_rdp(q=q, noise_multiplier=sigma, steps=steps, orders=orders)
 
     >>> epsilon, opt_order = get_privacy_spent(orders, rdp, delta=1e-5)
     >>> epsilon, opt_order  # doctest: +NUMBER

--- a/opacus/accountants/gdp.py
+++ b/opacus/accountants/gdp.py
@@ -8,7 +8,7 @@ class GaussianAccountant(IAccountant):
         self.sample_rate = None
         self.steps = 0
 
-    def step(self, noise_multiplier: float, sample_rate: float):
+    def step(self, *, noise_multiplier: float, sample_rate: float):
         if self.noise_multiplier is None:
             self.noise_multiplier = noise_multiplier
 
@@ -22,16 +22,17 @@ class GaussianAccountant(IAccountant):
         self.steps += 1
 
     def get_epsilon(self, delta: float, poisson: bool = True) -> float:
-        if poisson:
-            epsilon = privacy_analysis.compute_eps_poisson(
-                self.steps, self.noise_multiplier, self.sample_rate, delta
-            )
-        else:
-            epsilon = privacy_analysis.compute_eps_uniform(
-                self.steps, self.noise_multiplier, self.sample_rate, delta
-            )
-
-        return epsilon
+        compute_eps = (
+            privacy_analysis.compute_eps_poisson
+            if poisson
+            else privacy_analysis.compute_eps_uniform
+        )
+        return compute_eps(
+            steps=self.steps,
+            noise_multiplier=self.noise_multiplier,
+            sample_rate=self.sample_rate,
+            delta=delta,
+        )
 
     def __len__(self):
         return self.steps

--- a/opacus/accountants/rdp.py
+++ b/opacus/accountants/rdp.py
@@ -10,7 +10,7 @@ class RDPAccountant(IAccountant):
     def __init__(self):
         self.steps = []
 
-    def step(self, noise_multiplier: float, sample_rate: float):
+    def step(self, *, noise_multiplier: float, sample_rate: float):
         if len(self.steps) >= 1:
             last_noise_multiplier, last_sample_rate, num_steps = self.steps.pop()
             if (
@@ -28,28 +28,30 @@ class RDPAccountant(IAccountant):
             self.steps.append((noise_multiplier, sample_rate, 1))
 
     def get_privacy_spent(
-        self, delta: float, alphas: Optional[List[Union[float, int]]] = None
+        self, *, delta: float, alphas: Optional[List[Union[float, int]]] = None
     ) -> Tuple[float, float]:
         if alphas is None:
             alphas = self.DEFAULT_ALPHAS
-
         rdp = sum(
             [
                 privacy_analysis.compute_rdp(
-                    sample_rate, noise_multiplier, num_steps, alphas
+                    q=sample_rate,
+                    noise_multiplier=noise_multiplier,
+                    steps=num_steps,
+                    orders=alphas,
                 )
                 for (noise_multiplier, sample_rate, num_steps) in self.steps
             ]
         )
-
-        eps, best_alpha = privacy_analysis.get_privacy_spent(alphas, rdp, delta)
-
+        eps, best_alpha = privacy_analysis.get_privacy_spent(
+            orders=alphas, rdp=rdp, delta=delta
+        )
         return float(eps), float(best_alpha)
 
     def get_epsilon(
         self, delta: float, alphas: Optional[List[Union[float, int]]] = None
     ):
-        eps, _ = self.get_privacy_spent(delta, alphas)
+        eps, _ = self.get_privacy_spent(delta=delta, alphas=alphas)
         return eps
 
     def __len__(self):

--- a/opacus/accountants/utils.py
+++ b/opacus/accountants/utils.py
@@ -13,6 +13,7 @@ MAX_SIGMA = 2000
 
 
 def get_noise_multiplier(
+    *,
     target_epsilon: float,
     target_delta: float,
     sample_rate: float,

--- a/opacus/data_loader.py
+++ b/opacus/data_loader.py
@@ -146,7 +146,7 @@ class DPDataLoader(DataLoader):
 
     @classmethod
     def from_data_loader(
-        cls, data_loader: DataLoader, distributed: bool = False, generator=None
+        cls, data_loader: DataLoader, *, distributed: bool = False, generator=None
     ):
         """
         Creates new ``DPDataLoader`` based on passed ``data_loader`` argument.
@@ -194,7 +194,7 @@ def _is_supported_batch_sampler(sampler: Sampler):
     )
 
 
-def switch_generator(data_loader: DataLoader, generator):
+def switch_generator(*, data_loader: DataLoader, generator):
     """
     Creates new instance of a ``DataLoader``, with the exact same behaviour of the
     provided data loader, except for the source of randomness.

--- a/opacus/grad_sample/conv.py
+++ b/opacus/grad_sample/conv.py
@@ -29,7 +29,11 @@ def compute_conv_grad_sample(
     # get A and B in shape depending on the Conv layer
     if type(layer) == nn.Conv2d:
         activations = unfold2d(
-            activations, layer.kernel_size, layer.padding, layer.stride, layer.dilation
+            activations,
+            kernel_size=layer.kernel_size,
+            padding=layer.padding,
+            stride=layer.stride,
+            dilation=layer.dilation,
         )
         backprops = backprops.reshape(n, -1, activations.shape[-1])
     elif type(layer) == nn.Conv1d:
@@ -38,7 +42,7 @@ def compute_conv_grad_sample(
         # set arguments to tuples with appropriate second element
         activations = torch.nn.functional.unfold(
             activations,
-            (1, layer.kernel_size[0]),
+            kernel_size=(1, layer.kernel_size[0]),
             padding=(0, layer.padding[0]),
             stride=(1, layer.stride[0]),
             dilation=(1, layer.dilation[0]),

--- a/opacus/scheduler.py
+++ b/opacus/scheduler.py
@@ -4,7 +4,7 @@ from .optimizers import DPOptimizer
 
 
 class _NoiseScheduler(object):
-    def __init__(self, optimizer: DPOptimizer, last_epoch=-1):
+    def __init__(self, optimizer: DPOptimizer, *, last_epoch=-1):
         self.optimizer = optimizer
         self.last_epoch = last_epoch
 
@@ -46,7 +46,7 @@ class ExponentialNoise(_NoiseScheduler):
 
     """
 
-    def __init__(self, optimizer: DPOptimizer, gamma: float, last_epoch: int = -1):
+    def __init__(self, optimizer: DPOptimizer, *, gamma: float, last_epoch: int = -1):
         """
 
         Args:
@@ -55,7 +55,7 @@ class ExponentialNoise(_NoiseScheduler):
             last_epoch: The index of last epoch
         """
         self.gamma = gamma
-        super().__init__(optimizer, last_epoch)
+        super().__init__(optimizer, last_epoch=last_epoch)
 
     def get_noise_multiplier(self):
         if self.last_epoch == 0:
@@ -74,6 +74,7 @@ class LambdaNoise(_NoiseScheduler):
     def __init__(
         self,
         optimizer: DPOptimizer,
+        *,
         noise_lambda: Callable[[int], float],
         last_epoch: int = -1,
     ):
@@ -87,7 +88,7 @@ class LambdaNoise(_NoiseScheduler):
         """
         self.noise_lambda = noise_lambda
         self.base_noise_multiplier = optimizer.noise_multiplier
-        super().__init__(optimizer, last_epoch)
+        super().__init__(optimizer, last_epoch=last_epoch)
 
     def get_noise_multiplier(self):
         return self.base_noise_multiplier * self.noise_lambda(self.last_epoch)
@@ -101,7 +102,12 @@ class StepNoise(_NoiseScheduler):
     """
 
     def __init__(
-        self, optimizer: DPOptimizer, step_size: int, gamma: float, last_epoch: int = -1
+        self,
+        optimizer: DPOptimizer,
+        *,
+        step_size: int,
+        gamma: float,
+        last_epoch: int = -1,
     ):
         """
 
@@ -113,7 +119,7 @@ class StepNoise(_NoiseScheduler):
         """
         self.step_size = step_size
         self.gamma = gamma
-        super().__init__(optimizer, last_epoch)
+        super().__init__(optimizer, last_epoch=last_epoch)
 
     def get_noise_multiplier(self):
         # Only change noise_multiplier when at a 'step'

--- a/opacus/scripts/compute_dp_sgd_privacy.py
+++ b/opacus/scripts/compute_dp_sgd_privacy.py
@@ -33,6 +33,7 @@ from opacus.accountants.analysis.rdp import compute_rdp, get_privacy_spent
 
 
 def _apply_dp_sgd_analysis(
+    *,
     sample_rate: float,
     noise_multiplier: float,
     steps: int,
@@ -78,6 +79,7 @@ def _apply_dp_sgd_analysis(
 
 
 def compute_dp_sgd_privacy(
+    *,
     sample_rate: float,
     noise_multiplier: float,
     epochs: int,
@@ -112,7 +114,12 @@ def compute_dp_sgd_privacy(
     steps = epochs * math.ceil(1 / sample_rate)
 
     return _apply_dp_sgd_analysis(
-        sample_rate, noise_multiplier, steps, alphas, delta, verbose
+        sample_rate=sample_rate,
+        noise_multiplier=noise_multiplier,
+        steps=steps,
+        alphas=alphas,
+        delta=delta,
+        verbose=verbose,
     )
 
 

--- a/opacus/tests/accountants_test.py
+++ b/opacus/tests/accountants_test.py
@@ -14,7 +14,7 @@ class AccountingTest(unittest.TestCase):
 
         accountant = RDPAccountant()
         for _ in range(steps):
-            accountant.step(noise_multiplier, sample_rate)
+            accountant.step(noise_multiplier=noise_multiplier, sample_rate=sample_rate)
 
         epsilon = accountant.get_epsilon(delta=1e-5)
         self.assertAlmostEqual(epsilon, 7.32911117143)
@@ -26,7 +26,7 @@ class AccountingTest(unittest.TestCase):
 
         accountant = GaussianAccountant()
         for _ in range(steps):
-            accountant.step(noise_multiplier, sample_rate)
+            accountant.step(noise_multiplier=noise_multiplier, sample_rate=sample_rate)
 
         epsilon = accountant.get_epsilon(delta=1e-5)
         self.assertLess(6.59, epsilon)
@@ -38,6 +38,11 @@ class AccountingTest(unittest.TestCase):
         epsilon = 8
         epochs = 90
 
-        noise_multiplier = get_noise_multiplier(epsilon, delta, sample_rate, epochs)
+        noise_multiplier = get_noise_multiplier(
+            target_epsilon=epsilon,
+            target_delta=delta,
+            sample_rate=sample_rate,
+            epochs=epochs,
+        )
 
         self.assertAlmostEqual(noise_multiplier, 1.425307617)

--- a/opacus/tests/randomness_test.py
+++ b/opacus/tests/randomness_test.py
@@ -114,7 +114,7 @@ class DataLoaderSwitchRandomnessTest(TensorCompareTestCase):
             shuffle=shuffle,
             generator=orig_generator,
         )
-        dl = switch_generator(dl, new_generator)
+        dl = switch_generator(data_loader=dl, generator=new_generator)
         return _read_all(dl)
 
     def test_consistent(self):

--- a/opacus/utils/module_utils.py
+++ b/opacus/utils/module_utils.py
@@ -43,7 +43,7 @@ def trainable_modules(module: nn.Module) -> Iterable[nn.Module]:
     )
 
 
-def requires_grad(module: nn.Module, recurse: bool = False) -> bool:
+def requires_grad(module: nn.Module, *, recurse: bool = False) -> bool:
     """
     Checks if any parameters in a specified module require gradients.
 

--- a/opacus/utils/tensor_utils.py
+++ b/opacus/utils/tensor_utils.py
@@ -11,7 +11,7 @@ from torch.functional import F
 
 
 def calc_sample_norms(
-    named_params: Iterator[Tuple[str, torch.Tensor]], flat: bool = True
+    named_params: Iterator[Tuple[str, torch.Tensor]], *, flat: bool = True
 ) -> List[torch.Tensor]:
     r"""
     Calculates the norm of the given tensors for each sample.
@@ -103,6 +103,7 @@ def sum_over_all_but_batch_and_last_n(
 
 def unfold2d(
     input,
+    *,
     kernel_size: Tuple[int, int],
     padding: Tuple[int, int],
     stride: Tuple[int, int],
@@ -133,6 +134,7 @@ def unfold2d(
 
 def unfold3d(
     tensor: torch.Tensor,
+    *,
     kernel_size: Union[int, Tuple[int, int, int]],
     padding: Union[int, Tuple[int, int, int]] = 0,
     stride: Union[int, Tuple[int, int, int]] = 1,

--- a/opacus/utils/uniform_sampler.py
+++ b/opacus/utils/uniform_sampler.py
@@ -13,7 +13,7 @@ class UniformWithReplacementSampler(Sampler[List[int]]):
     Each sample is selected with a probability equal to ``sample_rate``.
     """
 
-    def __init__(self, num_samples: int, sample_rate: float, generator=None):
+    def __init__(self, *, num_samples: int, sample_rate: float, generator=None):
         r"""
         Args:
             num_samples (int): number of samples to draw.
@@ -65,6 +65,7 @@ class DistributedUniformWithReplacementSampler(Sampler):
 
     def __init__(
         self,
+        *,
         total_size: int,
         sample_rate: float,
         shuffle: bool = True,

--- a/opacus/validators/module_validator.py
+++ b/opacus/validators/module_validator.py
@@ -34,7 +34,7 @@ class ModuleValidator:
 
     @classmethod
     def validate(
-        cls, module: nn.Module, raise_if_error: bool = False
+        cls, module: nn.Module, *, raise_if_error: bool = False
     ) -> List[UnsupportedModuleError]:
         """
         Validate module and sub_modules by running registered custom validators.
@@ -121,6 +121,7 @@ class ModuleValidator:
     @classmethod
     def _repalce_sub_module(
         cls,
+        *,
         root: nn.Module,
         sub_module_name: str,
         new_sub_module: nn.Module,


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue
Force most of the APIs exposed by Opacus to comply with [PEP 3102](https://www.python.org/dev/peps/pep-3102/). This not only adds clarity to the API but also removes the reliance on position of args and allow us to be more flexible with API changes in the future. See #128 and subsequent fix in #136 for more context.

## How Has This Been Tested (if it applies)

Circle CI tests

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
