### PR TITLE
 PyTorch Lightning Example for API v1.0

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -16,4 +16,5 @@ datasets
 transformers
 scikit-learn
 pytorch-lightning
+lightning-bolts
 jsonargparse[signatures]>=3.19.3 # required for Lightning CLI

--- a/examples/mnist_lightning.py
+++ b/examples/mnist_lightning.py
@@ -15,8 +15,8 @@ To see logs:
 $ tensorboard --logdir=lightning_logs/
 """
 
+import os
 import warnings
-from typing import Optional
 
 import pytorch_lightning as pl
 import torch.nn as nn
@@ -24,10 +24,10 @@ import torch.nn.functional as F
 import torch.optim as optim
 import torchmetrics
 from opacus import PrivacyEngine
-from opacus.utils.uniform_sampler import UniformWithReplacementSampler
+from opacus.data_loader import DPDataLoader
+from opacus.lightning import DPLightningDataModule
+from pl_bolts.datamodules import MNISTDataModule
 from pytorch_lightning.utilities.cli import LightningCLI
-from torch.utils.data import DataLoader
-from torchvision import datasets, transforms
 
 
 warnings.filterwarnings("ignore")
@@ -39,32 +39,21 @@ class LitSampleConvNetClassifier(pl.LightningModule):
         lr: float = 0.1,
         enable_dp: bool = True,
         delta: float = 1e-5,
-        sample_rate: float = 0.001,
-        sigma: float = 1.0,
-        max_per_sample_grad_norm: float = 1.0,
-        secure_rng: bool = False,
+        noise_multiplier: float = 1.0,
+        max_grad_norm: float = 1.0,
     ):
-        """A simple conv-net for classifying MNIST with differential privacy
-
+        """A simple conv-net for classifying MNIST with differential privacy training
         Args:
             lr: Learning rate
             enable_dp: Enables training with privacy guarantees using Opacus (if True), vanilla SGD otherwise
             delta: Target delta for which (eps, delta)-DP is computed
-            sample_rate: Sample rate used for batch construction
-            sigma: Noise multiplier
-            max_per_sample_grad_norm: Clip per-sample gradients to this norm
-            secure_rng: Use secure random number generator
+            noise_multiplier: Noise multiplier
+            max_grad_norm: Clip per-sample gradients to this norm
         """
         super().__init__()
 
         # Hyper-parameters
         self.lr = lr
-        self.enable_dp = enable_dp
-        self.delta = delta
-        self.sample_rate = sample_rate
-        self.sigma = sigma
-        self.max_per_sample_grad_norm = max_per_sample_grad_norm
-        self.secure_rng = secure_rng
 
         # Parameters
         self.conv1 = nn.Conv2d(1, 16, 8, 2, padding=3)
@@ -72,11 +61,16 @@ class LitSampleConvNetClassifier(pl.LightningModule):
         self.fc1 = nn.Linear(32 * 4 * 4, 32)
         self.fc2 = nn.Linear(32, 10)
 
-        # Privacy engine
-        self.privacy_engine = None  # Created before training
-
         # Metrics
         self.test_accuracy = torchmetrics.Accuracy()
+
+        # Differential privacy
+        self.enable_dp = enable_dp
+        self.delta = delta
+        self.noise_multiplier = noise_multiplier
+        self.max_grad_norm = max_grad_norm
+        if self.enable_dp:
+            self.privacy_engine = PrivacyEngine()
 
     def forward(self, x):
         # x of shape [B, 1, 28, 28]
@@ -91,6 +85,27 @@ class LitSampleConvNetClassifier(pl.LightningModule):
 
     def configure_optimizers(self):
         optimizer = optim.SGD(self.parameters(), lr=self.lr, momentum=0)
+
+        if self.enable_dp:
+            data_loader = (
+                # soon there will be a fancy way to access train dataloader,
+                # see https://github.com/PyTorchLightning/pytorch-lightning/issues/10430
+                self.trainer._data_connector._train_dataloader_source.dataloader()
+            )
+
+            # transform (model, optimizer, dataloader) to DP-versions
+            if hasattr(self, "dp"):
+                self.dp["model"].remove_hooks()
+            dp_model, optimizer, dataloader = self.privacy_engine.make_private(
+                module=self,
+                optimizer=optimizer,
+                data_loader=data_loader,
+                noise_multiplier=self.noise_multiplier,
+                max_grad_norm=self.max_grad_norm,
+                poisson_sampling=isinstance(data_loader, DPDataLoader),
+            )
+            self.dp = {"model": dp_model}
+
         return optimizer
 
     def training_step(self, batch, batch_idx):
@@ -109,113 +124,35 @@ class LitSampleConvNetClassifier(pl.LightningModule):
         self.log("test_accuracy", self.test_accuracy, on_step=False, on_epoch=True)
         return loss
 
-    # Adding differential privacy learning
-
-    def on_train_start(self) -> None:
-        if self.enable_dp:
-            self.privacy_engine = PrivacyEngine(
-                self,
-                sample_rate=self.sample_rate,
-                alphas=[1 + x / 10.0 for x in range(1, 100)] + list(range(12, 64)),
-                noise_multiplier=self.sigma,
-                max_grad_norm=self.max_per_sample_grad_norm,
-                secure_rng=self.secure_rng,
-            )
-
-            optimizer = self.optimizers()
-            self.privacy_engine.attach(optimizer)
-
     def on_train_epoch_end(self):
-        if self.enable_dp:
-            epsilon, best_alpha = self.privacy_engine.get_privacy_spent(self.delta)
-            # Privacy spent: (epsilon, delta) for alpha
-            self.log("epsilon", epsilon, on_epoch=True, prog_bar=True)
-            self.log("alpha", best_alpha, on_epoch=True, prog_bar=True)
-
-    def on_train_end(self):
-        if self.enable_dp:
-            self.privacy_engine.detach()
+        # Logging privacy spent: (epsilon, delta)
+        epsilon = self.privacy_engine.get_epsilon(self.delta)
+        self.log("epsilon", epsilon, on_epoch=True, prog_bar=True)
 
 
-class MNISTDataModule(pl.LightningDataModule):
-    def __init__(
-        self,
-        data_dir: Optional[str] = "../mnist",
-        test_batch_size: int = 1024,
-        sample_rate: float = 0.001,
-        secure_rng: bool = False,
-    ):
-        """MNIST DataModule with DP-ready batch sampling
+def main():
+    """
+    Using vanilla Lightning API to train/test
+    """
+    data = MNISTDataModule(batch_size=64)
+    model = LitSampleConvNetClassifier()
 
-        Args:
-            data_dir: A path where MNIST is stored
-            test_batch_size: Size of batch for predicting on test
-            sample_rate: Sample rate used for batch construction
-            secure_rng: Use secure random number generator
-        """
-        super().__init__()
-        self.data_root = data_dir
-        self.dataloader_kwargs = {"num_workers": 1, "pin_memory": True}
+    dp_data = DPLightningDataModule(data)
 
-        self.save_hyperparameters()
+    trainer = pl.Trainer(
+        max_epochs=10,
+        enable_model_summary=False,
+    )
+    trainer.fit(model, dp_data)
 
-        if secure_rng:
-            try:
-                import torchcsprng as prng
-            except ImportError as e:
-                msg = (
-                    "To use secure RNG, you must install the torchcsprng package! "
-                    "Check out the instructions here: https://github.com/pytorch/csprng#installation"
-                )
-                raise ImportError(msg) from e
-            self.generator = prng.create_random_device_generator("/dev/urandom")
-        else:
-            self.generator = None
-
-    @property
-    def transform(self):
-        return transforms.Compose(
-            [
-                transforms.ToTensor(),
-                transforms.Normalize((0.1307,), (0.3081,)),
-            ]
-        )
-
-    def prepare_data(self) -> None:
-        datasets.MNIST(self.data_root, download=True)
-
-    def train_dataloader(self):
-        train_dataset = datasets.MNIST(
-            self.data_root,
-            train=True,
-            download=False,
-            transform=self.transform,
-        )
-        return DataLoader(
-            train_dataset,
-            batch_sampler=UniformWithReplacementSampler(
-                num_samples=len(train_dataset),
-                sample_rate=self.hparams.sample_rate,
-                generator=self.generator,
-            ),
-            **self.dataloader_kwargs,
-        )
-
-    def test_dataloader(self):
-        return DataLoader(
-            datasets.MNIST(
-                self.data_root,
-                train=False,
-                download=False,
-                transform=self.transform,
-            ),
-            batch_size=self.hparams.test_batch_size,
-            shuffle=True,
-            **self.dataloader_kwargs,
-        )
+    trainer.test(model, data)
+    trainer.test(model, dp_data)  # identical
 
 
 def cli_main():
+    """
+    Using LightningCLI to automatically setup argparse
+    """
     cli = LightningCLI(
         LitSampleConvNetClassifier,
         MNISTDataModule,
@@ -231,4 +168,7 @@ def cli_main():
 
 
 if __name__ == "__main__":
-    cli_main()
+    if os.environ.get("LIGHTNING_VANILLA") == "true":
+        main()
+    else:
+        cli_main()

--- a/opacus/lightning.py
+++ b/opacus/lightning.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from typing import Any, Optional
+
+import pytorch_lightning as pl
+import torch
+from opacus.data_loader import DPDataLoader
+
+
+class DPLightningDataModule(pl.LightningDataModule):
+    def __init__(
+        self,
+        datamodule: pl.LightningDataModule,
+        generator: Optional[torch.Generator] = None,
+    ):
+        super().__init__()
+        self.datamodule = datamodule
+        self.generator = generator
+
+    def prepare_data(self) -> None:
+        self.datamodule.prepare_data()
+
+    def setup(self, stage: Optional[str] = None) -> None:
+        self.datamodule.setup(stage)
+
+    def train_dataloader(self):
+        dataloader = self.datamodule.train_dataloader()
+        return DPDataLoader.from_data_loader(dataloader, distributed=False)
+
+    def val_dataloader(self):
+        return self.datamodule.val_dataloader()
+
+    def test_dataloader(self):
+        return self.datamodule.test_dataloader()
+
+    def predict_dataloader(self):
+        return self.datamodule.predict_dataloader()
+
+    def transfer_batch_to_device(
+        self, batch: Any, device: torch.device, dataloader_idx: int
+    ) -> Any:
+        return self.datamodule.transfer_batch_to_device(batch, device, dataloader_idx)
+
+    def on_before_batch_transfer(self, batch: Any, dataloader_idx: int) -> Any:
+        return self.datamodule.on_before_batch_transfer(batch, dataloader_idx)
+
+    def on_after_batch_transfer(self, batch: Any, dataloader_idx: int) -> Any:
+        return self.datamodule.on_after_batch_transfer(batch, dataloader_idx)

--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -471,10 +471,9 @@ class DPOptimizer(Optimizer):
         return True
 
     def step(self, closure: Optional[Callable[[], float]] = None) -> Optional[float]:
-        loss = None
         if closure is not None:
             with torch.enable_grad():
-                loss = closure()
+                closure()
 
         if self.pre_step():
             return self.original_optimizer.step(closure)

--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -456,7 +456,6 @@ class DPOptimizer(Optimizer):
             closure: A closure that reevaluates the model and
                 returns the loss. Optional for most optimizers.
         """
-
         self.clip_and_accumulate()
         if self._check_skip_next_step():
             self._is_last_step_skipped = True
@@ -472,7 +471,11 @@ class DPOptimizer(Optimizer):
         return True
 
     def step(self, closure: Optional[Callable[[], float]] = None) -> Optional[float]:
-        # TODO: handle closure call - we should do it before pre_step()
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
         if self.pre_step():
             return self.original_optimizer.step(closure)
         else:


### PR DESCRIPTION
Example demonstrating how Opacus v1.0 API can be used with PyTorch Lightning. This is a follow-up for #250. 

## Changes

Added `mnist_lightning.py` with the classifier allowing training with DP. 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## How Has This Been Tested (if it applies)


All unit tests plus running the example:

```
python mnist_lightning.py fit --trainer.max_epochs 2
VANILLA_LIGHTNING=true python mnist_lightning.py
```

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
