### PR TITLE
fix docstring for PrivacyEngine.get_epsilon()

### DIFF
--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -457,6 +457,6 @@ class PrivacyEngine:
             delta: The target delta.
 
         Returns:
-            Pair of epsilon and optimal order alpha.
+            Privacy budget (epsilon) expended so far.
         """
         return self.accountant.get_epsilon(delta)


### PR DESCRIPTION
Fix docstring for `PrivacyEngine.get_epsilon()`

While `RDP.get_privacy_spent(delta, alphas)` returns both epsilon and optimal alpha,`self.accountant.get_epsilon(delta)` returns only epsilon for both GDP and RDP.