### PR TITLE
minor fix to incorrect api call in tutorial

### DIFF
--- a/tutorials/building_image_classifier.ipynb
+++ b/tutorials/building_image_classifier.ipynb
@@ -214,7 +214,7 @@
    "source": [
     "from opacus.validators import ModuleValidator\n",
     "\n",
-    "errors = ModuleValidator.validate(model, raise_if_error=False)\n",
+    "errors = ModuleValidator.validate(model, strict=False)\n",
     "errors[-5:]"
    ]
   },
@@ -246,7 +246,7 @@
    ],
    "source": [
     "model = ModuleValidator.fix(model)\n",
-    "ModuleValidator.validate(model, raise_if_error=False)"
+    "ModuleValidator.validate(model, strict=False)"
    ]
   },
   {


### PR DESCRIPTION
## Fix 2 API calls in the tutorials for building an image classifier

- Bug fix (non-breaking change which fixes an issue)

## Motivation and Context / Related issue

Running the tutorial would fail unless you have the right api calls.
## How Has This Been Tested (if it applies)
 I ran the tutorial

## Checklist

- [x ] The documentation is up-to-date with the changes I made.
- [ x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
I did not run additional tests