### PR TITLE
Add support for GDP accounting in get_noise_multiplier

### DIFF
--- a/opacus/accountants/gdp.py
+++ b/opacus/accountants/gdp.py
@@ -4,22 +4,23 @@ from .analysis import gdp as privacy_analysis
 
 class GaussianAccountant(IAccountant):
     def __init__(self):
-        self.noise_multiplier = None
-        self.sample_rate = None
-        self.steps = 0
+        self.steps = []
 
     def step(self, *, noise_multiplier: float, sample_rate: float):
-        if self.noise_multiplier is None:
-            self.noise_multiplier = noise_multiplier
+        if len(self.steps) >= 1:
+            last_noise_multiplier, last_sample_rate, num_steps = self.steps.pop()
+            if (
+                last_noise_multiplier != noise_multiplier
+                or last_sample_rate != sample_rate
+            ):
+                raise ValueError(
+                    "Noise multiplier and sample rate have to stay constant in GaussianAccountant."
+                )
+            else:
+                self.steps = [(last_noise_multiplier, last_sample_rate, num_steps + 1)]
 
-        if self.sample_rate is None:
-            self.sample_rate = sample_rate
-
-        if noise_multiplier != self.noise_multiplier or sample_rate != self.sample_rate:
-            raise ValueError(
-                "Noise multiplier and sample rate have to stay constant in GaussianAccountant."
-            )
-        self.steps += 1
+        else:
+            self.steps = [(noise_multiplier, sample_rate, 1)]
 
     def get_epsilon(self, delta: float, poisson: bool = True) -> float:
         """
@@ -36,15 +37,16 @@ class GaussianAccountant(IAccountant):
             if poisson
             else privacy_analysis.compute_eps_uniform
         )
+        noise_multiplier, sample_rate, num_steps = self.steps.pop()
         return compute_eps(
-            steps=self.steps,
-            noise_multiplier=self.noise_multiplier,
-            sample_rate=self.sample_rate,
+            steps=num_steps,
+            noise_multiplier=noise_multiplier,
+            sample_rate=sample_rate,
             delta=delta,
         )
 
     def __len__(self):
-        return self.steps
+        return len(self.steps)
 
     @classmethod
     def mechanism(cls) -> str:

--- a/opacus/tests/accountants_test.py
+++ b/opacus/tests/accountants_test.py
@@ -32,7 +32,7 @@ class AccountingTest(unittest.TestCase):
         self.assertLess(6.59, epsilon)
         self.assertLess(epsilon, 6.6)
 
-    def test_get_noise_multiplier(self):
+    def test_get_noise_multiplier_rdp(self):
         delta = 1e-5
         sample_rate = 0.04
         epsilon = 8
@@ -43,6 +43,23 @@ class AccountingTest(unittest.TestCase):
             target_delta=delta,
             sample_rate=sample_rate,
             epochs=epochs,
+            accountant="rdp",
         )
 
         self.assertAlmostEqual(noise_multiplier, 1.425307617)
+
+    def test_get_noise_multiplier_gdp(self):
+        delta = 1e-5
+        sample_rate = 0.04
+        epsilon = 8
+        epochs = 90
+
+        noise_multiplier = get_noise_multiplier(
+            target_epsilon=epsilon,
+            target_delta=delta,
+            sample_rate=sample_rate,
+            epochs=epochs,
+            accountant="gdp",
+        )
+
+        self.assertAlmostEqual(noise_multiplier, 1.327700195)


### PR DESCRIPTION
The PR adds support for GDP accounting in get_noise_multiplier.

This is done by making the GDP accountant work more like the RDP accountant: Keep the list of parameters in `self.steps` (as opposed to having `self.steps` being an integer as before). This change in behavior, however, does not affect the public interface of the GDP accountant.

## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue
<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
This PR solves a TODO in code. The problem is that the `get_noise_multiplier` function currently cannot leverage the GDP accounting mechanism.

## How Has This Been Tested (if it applies)
A respective unit test was added in `opacus/tests/accountants_test.py`
<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
