### PR TITLE
Migration guide code fix

### DIFF
--- a/Migration_Guide.md
+++ b/Migration_Guide.md
@@ -208,7 +208,7 @@ dp_optimizer = DPOptimizer(
 )
 
 # attack accountant to track privacy for an optimizer
-optimizer.attach_step_hook(
+dp_optimizer.attach_step_hook(
     accountant.get_optimizer_hook_fn(
       # this is an important parameter for privacy accounting. Should be equal to batch_size / len(dataset)
       sample_rate=sample_rate


### PR DESCRIPTION
Summary: As discovered on [PyTorch forums](https://discuss.pytorch.org/t/new-version-opacus-without-dataloader/138517/2), there's a typo in migration guide - hooks should be attached to the dp_optimizer, not the original optimizer.

Differential Revision: D32949694

