### PR TITLE
[DOCS] Obsolete arguments in docstring.

### DIFF
--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -299,8 +299,6 @@ class PrivacyEngine:
                 ``[K, batch_size, ...]``
             loss_reduction: Indicates if the loss reduction (for aggregating the gradients)
                 is a sum or a mean operation. Can take values "sum" or "mean"
-            noise_generator: torch.Generator() used as a source of randomness for
-                gaussian noise generation
             poisson_sampling: ``True`` if you want to use standard sampling required
                 for DP guarantees. Setting ``False`` will leave provided data_loader
                 unchanged. Technically this doesn't fit the assumptions made by


### PR DESCRIPTION
There are two noise_generator parameters in the [documentation](https://opacus.ai/api/privacy_engine.html#opacus.privacy_engine.PrivacyEngine.make_private) of the `make_private` method. 

Removed obsolete input arguments in docstrings:

https://github.com/pytorch/opacus/blob/5cd23cf8040b15460ebf317b2f3ef0cee9e39ad6/opacus/privacy_engine.py#L302-L303

which is duplicate of 

https://github.com/pytorch/opacus/blob/5cd23cf8040b15460ebf317b2f3ef0cee9e39ad6/opacus/privacy_engine.py#L315-L316

---

## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Just for the sake of better documents.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

Since no code is added, I would assume that no tests would be required and the document should be up to date.

Cheers.