### PR TITLE
FIX #311: Hidden states of RNN not passed into device.

### DIFF
--- a/opacus/layers/dp_rnn.py
+++ b/opacus/layers/dp_rnn.py
@@ -428,10 +428,10 @@ class DPRNNBase(RenameParamsMixin, nn.Module):
             if self.batch_first:
                 output = output.transpose(0, 1)
 
-        hs = torch.stack(hs, dim=0)  # [L*P, B, H]
+        hs = torch.stack(hs, dim=0).to(device)  # [L*P, B, H]
         hs = apply_permutation(hs, 1, unsorted_indices)
         if self.has_cell_state:
-            cs = torch.stack(cs, dim=0)  # [L*P, B, H]
+            cs = torch.stack(cs, dim=0).to(device)  # [L*P, B, H]
             cs = apply_permutation(cs, 1, unsorted_indices)
 
         hidden = (hs, cs) if self.has_cell_state else hs


### PR DESCRIPTION
This would raise `RuntimeError` when `apply_permutation` function is
being called if the model is passed into a GPU device and the input
tensors are not.

## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
#311: Hidden states of RNN not passed into device.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
This has been tested using the code from this [colab](https://colab.research.google.com/drive/1RysLoStXqxaft4TbyFxGj_kx-Sa355ir?usp=sharing) on my system locally would no longer raise this error.

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.

I'm not sure if this requires other tests, and I'm not really familiar with running `unittest`. Any suggestions or feedback are welcomed. Cheers.
