### PR TITLE
Fix: Passing through `defaults` in DPOptimizer

### DIFF
--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -263,6 +263,7 @@ class DPOptimizer(Optimizer):
         self.secure_mode = secure_mode
 
         self.param_groups = optimizer.param_groups
+        self.defaults = self.original_optimizer.defaults
         self.state = optimizer.state
         self._step_skip_queue = []
         self._is_last_step_skipped = False


### PR DESCRIPTION
## Problem 

Described in #322. The code using schedules can be broken because DPOptimizer doesn't have `.defaults` field. For example, when using NAdam, schedulers with cycle_momentum=True.

## Solution

As suggested by @gkaissis, just passing through the `defaults` field to DPOptimizer.

Differential Revision: D33634214

