### PR TITLE
Fix: Closure call after applying DP noise

### DIFF
--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -476,7 +476,7 @@ class DPOptimizer(Optimizer):
                 closure()
 
         if self.pre_step():
-            return self.original_optimizer.step(closure)
+            return self.original_optimizer.step()
         else:
             return None
 

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -143,6 +143,7 @@ class BasePrivacyEngineTest(ABC):
 
         for _ in range(epochs):
             for x, y in dl:
+
                 def closure():
                     optimizer.zero_grad()
                     logits = model(x)


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Bug

In DPOptimizer step we apply noise to the gradients after then call `original_optimizer.step()`. 
If `closure` is used we should run it manually and then re-apply noise before making an optimizer step. The problem is that we pass closure to the original_optimizer causing it to re-compute gradients and clear up the noise. This removes the DP functionality. 

Closure is used when the optimizer needs more than one forward-backward passes. Also it's always used when using [automatic optimization](https://pytorch-lightning.readthedocs.io/en/stable/common/optimizers.html) in Pytorch Lightning (causing #313).

Interestingly, I already fixed this problem, but we we've lost the change. Probably during me migrating to the v1.0 API or while merging.

## Solution

We solve this by not passing the closure to the original optimizer while running it manually before making a step.

`privacy_engine_test.py` suite is updated to ensure the noise is added when passing `closure` to DPOptimizer.

## Further work

This solution is temporary because it doesn't support optimizers requiring more than one model evaluations to make a step (in this case the optimizer should raise due to `closure=None`). We need a design change to tackle this. What quickly comes to mind, we can wrap closure including add_noise into the wrapper.

Another question: how several model evaluations affect DP. E.g. how DP-LBFGS should work? 