### PR TITLE
DPOptimizer.step: Better exception message when p.grad_sample=None

### DIFF
--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -180,6 +180,10 @@ def _get_flat_grad_sample(p: torch.Tensor):
         raise ValueError(
             "Per sample gradient not found. Are you using GradSampleModule?"
         )
+    if p.grad_sample is None:
+        raise ValueError(
+            "Per sample gradient is not initialized. Not updated in backward pass?"
+        )
     if isinstance(p.grad_sample, torch.Tensor):
         return p.grad_sample
     elif isinstance(p.grad_sample, list):


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Enhancement

It is easy to run DPOptimizer.step while no all parameters has non-empty grad_sample, see #312 (at least 3 experienced this). A simple solution is make exception string look less like a library error.

## Better Solution 

Better solution could be to print the name of the parameter with empty grad_sample.