### PR TITLE
Use correct data loader variable in cifar tutorial

### DIFF
--- a/opacus/validators/module_validator.py
+++ b/opacus/validators/module_validator.py
@@ -74,6 +74,7 @@ class ModuleValidator:
         """
         return len(cls.validate(module, strict=False)) == 0
 
+    # TODO: fix method doesn't respect devices: new modules are always created on cpu
     @classmethod
     def fix(cls, module: nn.Module) -> nn.Module:
         """

--- a/tutorials/building_image_classifier.ipynb
+++ b/tutorials/building_image_classifier.ipynb
@@ -336,7 +336,7 @@
     "\n",
     "privacy_engine = PrivacyEngine()\n",
     "\n",
-    "model, optimizer, data_loader = privacy_engine.make_private_with_epsilon(\n",
+    "model, optimizer, train_loader = privacy_engine.make_private_with_epsilon(\n",
     "    module=model,\n",
     "    optimizer=optimizer,\n",
     "    data_loader=train_loader,\n",


### PR DESCRIPTION
As correctly pointed by @RoyRin in #308, image classifier tutorial doesn't use the data loader returned from the `make_private` (which it should)