### PR TITLE
lint for updated black version

### DIFF
--- a/opacus/accountants/analysis/rdp.py
+++ b/opacus/accountants/analysis/rdp.py
@@ -120,7 +120,7 @@ def _compute_log_a_for_int_alpha(q: float, sigma: float, alpha: int) -> float:
             + (alpha - i) * math.log(1 - q)
         )
 
-        s = log_coef_i + (i * i - i) / (2 * (sigma ** 2))
+        s = log_coef_i + (i * i - i) / (2 * (sigma**2))
         log_a = _log_add(log_a, s)
 
     return float(log_a)
@@ -150,7 +150,7 @@ def _compute_log_a_for_frac_alpha(q: float, sigma: float, alpha: float) -> float
     log_a0, log_a1 = -np.inf, -np.inf
     i = 0
 
-    z0 = sigma ** 2 * math.log(1 / q - 1) + 0.5
+    z0 = sigma**2 * math.log(1 / q - 1) + 0.5
 
     while True:  # do ... until loop
         coef = special.binom(alpha, i)
@@ -163,8 +163,8 @@ def _compute_log_a_for_frac_alpha(q: float, sigma: float, alpha: float) -> float
         log_e0 = math.log(0.5) + _log_erfc((i - z0) / (math.sqrt(2) * sigma))
         log_e1 = math.log(0.5) + _log_erfc((z0 - j) / (math.sqrt(2) * sigma))
 
-        log_s0 = log_t0 + (i * i - i) / (2 * (sigma ** 2)) + log_e0
-        log_s1 = log_t1 + (j * j - j) / (2 * (sigma ** 2)) + log_e1
+        log_s0 = log_t0 + (i * i - i) / (2 * (sigma**2)) + log_e0
+        log_s1 = log_t1 + (j * j - j) / (2 * (sigma**2)) + log_e1
 
         if coef > 0:
             log_a0 = _log_add(log_a0, log_s0)
@@ -217,7 +217,7 @@ def _log_erfc(x: float) -> float:
     Returns:
         :math:`log(erfc(x))`
     """
-    return math.log(2) + special.log_ndtr(-x * 2 ** 0.5)
+    return math.log(2) + special.log_ndtr(-x * 2**0.5)
 
 
 def _compute_rdp(q: float, sigma: float, alpha: float) -> float:
@@ -239,7 +239,7 @@ def _compute_rdp(q: float, sigma: float, alpha: float) -> float:
         return np.inf
 
     if q == 1.0:
-        return alpha / (2 * sigma ** 2)
+        return alpha / (2 * sigma**2)
 
     if np.isinf(alpha):
         return np.inf

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -491,9 +491,9 @@ class BasePrivacyEngineTest(ABC):
             expected_norm = (
                 steps
                 * n_params
-                * optimizer.noise_multiplier ** 2
-                * self.LR ** 2
-                / (optimizer.expected_batch_size ** 2)
+                * optimizer.noise_multiplier**2
+                * self.LR**2
+                / (optimizer.expected_batch_size**2)
             )
             real_norm = sum(
                 [torch.sum(torch.pow(p.data, 2)) for p in model.parameters()]

--- a/opacus/tests/scheduler_test.py
+++ b/opacus/tests/scheduler_test.py
@@ -47,7 +47,7 @@ class SchedulerTest(unittest.TestCase):
         scheduler.step()
         self.assertEqual(self.optimizer.noise_multiplier, gamma)
         scheduler.step()
-        self.assertEqual(self.optimizer.noise_multiplier, gamma ** 2)
+        self.assertEqual(self.optimizer.noise_multiplier, gamma**2)
 
     def test_lambda_scheduler(self):
         def noise_lambda(epoch):


### PR DESCRIPTION
Our lint check started to [fail](https://app.circleci.com/pipelines/github/pytorch/opacus/1597/workflows/fa07e367-0450-4eed-b0f7-8871936119f8/jobs/8591) due to `black` update (new version 22.1.0).

Reformatting the code 