### PR TITLE
Fix per-layer clipping in distributed

### DIFF
--- a/opacus/optimizers/ddpoptimizer.py
+++ b/opacus/optimizers/ddpoptimizer.py
@@ -57,7 +57,7 @@ class DistributedDPOptimizer(DPOptimizer):
             super().add_noise()
         else:
             for p in self.params:
-                p.grad = p.summed_grad
+                p.grad = p.summed_grad.view_as(p.grad)
 
     def reduce_gradients(self):
         for p in self.params:


### PR DESCRIPTION
### Problem

`DDPPerLayerOptimizer` was buggy and our test did not catch that. 

### Changes

Per-layer clipping uses the regular pytorch DDP (Distributed Data Parallel) instead of our custom DPDDP (Differentially Private DDP). Our PrivacyEngine only checked for DPDDP and not for DDP.
I fixed PrivacyEngine to have distributed=True if wrapper is DDP instead of DPDDP. 

This made the test non-buggy and I modified DPDDP to pass the test (adding `_check_skip_next_step` on step, adding `if self._step_skip_queue and self._step_skip_queue[0]` when doing per-parameter noise)
