### PR TITLE
Conservative search for target epsilon in get_noise_multiplier

### DIFF
--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -433,7 +433,7 @@ class BasePrivacyEngineTest(ABC):
             epochs=epochs,
             max_grad_norm=1.0,
         )
-        self._train_steps(model, optimizer, dl, max_steps=total_steps)
+        self._train_steps(model, optimizer, poisson_dl, max_steps=total_steps)
         self.assertAlmostEqual(
             target_eps, privacy_engine.get_epsilon(target_delta), places=2
         )


### PR DESCRIPTION
## Problem

@tholop noticed in #346 that `get_noise_multiplier` can overshoot the target epsilon when searching for highest possible noise multiplier. This is because of the binary search implementation.

## Changes

- Noise multiplier now verifies that the actual epsilon is *lower* than the target epsilon.
  - Added test for this.  
- Bounds of the range of search for sigma, and precision can now be given as arguments to `get_noise_multiplier`.

Differential Revision: D34003401

