### PR TITLE
Warn and ignore "drop_last" when set in DPDataLoader

### DIFF
--- a/opacus/data_loader.py
+++ b/opacus/data_loader.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Any, Optional, Sequence
 
 import torch
@@ -23,6 +24,7 @@ from torch.utils.data import BatchSampler, DataLoader, Dataset, IterableDataset,
 from torch.utils.data._utils.collate import default_collate
 from torch.utils.data.dataloader import _collate_fn_t, _worker_init_fn_t
 
+logger = logging.getLogger(__name__)
 
 def wrap_collate_with_empty(
     collate_fn: Optional[_collate_fn_t], sample_empty_shapes: Sequence
@@ -143,13 +145,15 @@ class DPDataLoader(DataLoader):
         if collate_fn is None:
             collate_fn = default_collate
 
+        if drop_last:
+            logger.warning("Ignoring drop_last as it is not compatible with DPDataLoader.")
+
         super().__init__(
             dataset=dataset,
             batch_sampler=batch_sampler,
             num_workers=num_workers,
             collate_fn=wrap_collate_with_empty(collate_fn, sample_empty_shapes),
             pin_memory=pin_memory,
-            drop_last=drop_last,
             timeout=timeout,
             worker_init_fn=worker_init_fn,
             multiprocessing_context=multiprocessing_context,

--- a/opacus/tests/dpdataloader_test.py
+++ b/opacus/tests/dpdataloader_test.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 from opacus.data_loader import DPDataLoader
-from torch.utils.data import TensorDataset
+from torch.utils.data import DataLoader, TensorDataset
 
 
 class DPDataLoaderTest(unittest.TestCase):
@@ -45,3 +45,10 @@ class DPDataLoaderTest(unittest.TestCase):
         (s,) = next(iter(data_loader))
 
         self.assertEqual(s.size(0), 0)
+
+    def test_drop_last_true(self):
+        x = torch.randn(self.data_size, self.dimension)
+
+        dataset = TensorDataset(x)
+        data_loader = DataLoader(dataset, drop_last=True)
+        _ = DPDataLoader.from_data_loader(data_loader)


### PR DESCRIPTION
Summary: Add a warning to show "drop_last" is being ignored and is not compatible with DPDataLoader

Differential Revision: D34197820

