### PR TITLE
Add support for GDP accounting in get_noise_multiplier (#303)

### DIFF
--- a/opacus/accountants/gdp.py
+++ b/opacus/accountants/gdp.py
@@ -18,22 +18,23 @@ from .analysis import gdp as privacy_analysis
 
 class GaussianAccountant(IAccountant):
     def __init__(self):
-        self.noise_multiplier = None
-        self.sample_rate = None
-        self.steps = 0
+        self.history = [] # history of noise multiplier, sample rate, and steps
 
     def step(self, *, noise_multiplier: float, sample_rate: float):
-        if self.noise_multiplier is None:
-            self.noise_multiplier = noise_multiplier
+        if len(self.history) >= 1:
+            last_noise_multiplier, last_sample_rate, num_steps = self.history.pop()
+            if (
+                last_noise_multiplier != noise_multiplier
+                or last_sample_rate != sample_rate
+            ):
+                raise ValueError(
+                    "Noise multiplier and sample rate have to stay constant in GaussianAccountant."
+                )
+            else:
+                self.history = [(last_noise_multiplier, last_sample_rate, num_steps + 1)]
 
-        if self.sample_rate is None:
-            self.sample_rate = sample_rate
-
-        if noise_multiplier != self.noise_multiplier or sample_rate != self.sample_rate:
-            raise ValueError(
-                "Noise multiplier and sample rate have to stay constant in GaussianAccountant."
-            )
-        self.steps += 1
+        else:
+            self.history = [(noise_multiplier, sample_rate, 1)]
 
     def get_epsilon(self, delta: float, poisson: bool = True) -> float:
         """
@@ -50,15 +51,16 @@ class GaussianAccountant(IAccountant):
             if poisson
             else privacy_analysis.compute_eps_uniform
         )
+        noise_multiplier, sample_rate, num_steps = self.history.pop()
         return compute_eps(
-            steps=self.steps,
-            noise_multiplier=self.noise_multiplier,
-            sample_rate=self.sample_rate,
+            steps=num_steps,
+            noise_multiplier=noise_multiplier,
+            sample_rate=sample_rate,
             delta=delta,
         )
 
     def __len__(self):
-        return self.steps
+        return len(self.history)
 
     @classmethod
     def mechanism(cls) -> str:

--- a/opacus/accountants/utils.py
+++ b/opacus/accountants/utils.py
@@ -43,11 +43,6 @@ def get_noise_multiplier(
     Returns:
         The noise level sigma to ensure privacy budget of (target_epsilon, target_delta)
     """
-    if accountant != "rdp":
-        # TODO: rewrite method to accept GDP
-        raise NotImplementedError(
-            "get_noise_multiplier is currently only supports RDP accountant"
-        )
     if (steps is None) == (epochs is None):
         raise ValueError(
             "get_noise_multiplier takes as input EITHER a number of steps or a number of epochs"
@@ -61,14 +56,14 @@ def get_noise_multiplier(
     sigma_low, sigma_high = 0, 10
     while eps_high > target_epsilon:
         sigma_high = 2 * sigma_high
-        accountant.steps = [(sigma_high, sample_rate, int(epochs / sample_rate))]
+        accountant.history = [(sigma_high, sample_rate, int(epochs / sample_rate))]
         eps_high = accountant.get_epsilon(delta=target_delta, **kwargs)
         if sigma_high > MAX_SIGMA:
             raise ValueError("The privacy budget is too low.")
 
     while target_epsilon - eps_high > epsilon_tolerance:
         sigma = (sigma_low + sigma_high) / 2
-        accountant.steps = [(sigma, sample_rate, steps)]
+        accountant.history = [(sigma, sample_rate, steps)]
         eps = accountant.get_epsilon(delta=target_delta, **kwargs)
 
         if eps < target_epsilon:

--- a/opacus/tests/accountants_test.py
+++ b/opacus/tests/accountants_test.py
@@ -47,7 +47,7 @@ class AccountingTest(unittest.TestCase):
         self.assertLess(6.59, epsilon)
         self.assertLess(epsilon, 6.6)
 
-    def test_get_noise_multiplier(self):
+    def test_get_noise_multiplier_rdp(self):
         delta = 1e-5
         sample_rate = 0.04
         epsilon = 8
@@ -58,6 +58,7 @@ class AccountingTest(unittest.TestCase):
             target_delta=delta,
             sample_rate=sample_rate,
             epochs=epochs,
+            accountant="rdp",
         )
 
         self.assertAlmostEqual(noise_multiplier, 1.416, places=4)
@@ -81,7 +82,23 @@ class AccountingTest(unittest.TestCase):
         )
 
         accountant = create_accountant(mechanism="rdp")
-        accountant.steps = [(noise_multiplier, sample_rate, int(epochs / sample_rate))]
+        accountant.history = [(noise_multiplier, sample_rate, int(epochs / sample_rate))]
 
         actual_epsilon = accountant.get_epsilon(delta=delta)
         self.assertLess(actual_epsilon, epsilon)
+
+    def test_get_noise_multiplier_gdp(self):
+        delta = 1e-5
+        sample_rate = 0.04
+        epsilon = 8
+        epochs = 90
+
+        noise_multiplier = get_noise_multiplier(
+            target_epsilon=epsilon,
+            target_delta=delta,
+            sample_rate=sample_rate,
+            epochs=epochs,
+            accountant="gdp",
+        )
+
+        self.assertAlmostEqual(noise_multiplier, 1.3232421875)


### PR DESCRIPTION
Summary:
The PR adds support for GDP accounting in get_noise_multiplier.

This is done by making the GDP accountant work more like the RDP accountant: Keep the list of parameters in `self.steps` (as opposed to having `self.steps` being an integer as before). This change in behavior, however, does not affect the public interface of the GDP accountant.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

This PR solves a TODO in code. The problem is that the `get_noise_multiplier` function currently cannot leverage the GDP accounting mechanism.

## How Has This Been Tested (if it applies)
A respective unit test was added in `opacus/tests/accountants_test.py`

## Checklist

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.

Pull Request resolved: https://github.com/pytorch/opacus/pull/303

Reviewed By: alexandresablayrolles

Differential Revision: D32933812

Pulled By: ashkan-software

