### PR TITLE
Run linter on nightly workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,6 +407,8 @@ workflows:
           filters: *exclude_ghpages
       - integrationtest_py37_torch_release_cuda:
           filters: *exclude_ghpages
+      - lint_py37_torch_release:
+          filters: *exclude_ghpages
 
   website_deployment:
     jobs:


### PR DESCRIPTION
Oftentimes we overlook linter errors when landing a pull request, which then makes it harder for external contributors to land their changes - they get failed linter checks and red CircleCI through no fault of their own.

I suggest we make lint fails more visible by running corresponding checks on nightly CircleCI flow (currently we only run linter on commits)