### PR TITLE
add warning for Gaussian DP accounting

### DIFF
--- a/opacus/accountants/gdp.py
+++ b/opacus/accountants/gdp.py
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 from .accountant import IAccountant
 from .analysis import gdp as privacy_analysis
 
 
 class GaussianAccountant(IAccountant):
     def __init__(self):
+        warnings.warn(
+            "GDP accounting is experimental and can underestimate privacy expendeture."
+            "Proceed with caution. More details: https://arxiv.org/pdf/2106.02848.pdf"
+        )
         self.history = []  # history of noise multiplier, sample rate, and steps
 
     def step(self, *, noise_multiplier: float, sample_rate: float):

--- a/opacus/accountants/gdp.py
+++ b/opacus/accountants/gdp.py
@@ -21,7 +21,7 @@ from .analysis import gdp as privacy_analysis
 class GaussianAccountant(IAccountant):
     def __init__(self):
         warnings.warn(
-            "GDP accounting is experimental and can underestimate privacy expendeture."
+            "GDP accounting is experimental and can underestimate privacy expenditure."
             "Proceed with caution. More details: https://arxiv.org/pdf/2106.02848.pdf"
         )
         self.history = []  # history of noise multiplier, sample rate, and steps


### PR DESCRIPTION
As discussed in #384, there's [evidence](https://arxiv.org/pdf/2106.02848.pdf) that GDP accounting can underestimate epsilon (which accounting isn't supposed to do, it could only should overshoot in the opposite direction).

We don't want to remove the code altogether if people know what they're doing, but we want to warn people that it's not recommended if they're not aware