### PR TITLE
Extract the input projections to a dedicated module.

### DIFF
--- a/opacus/grad_sample/__init__.py
+++ b/opacus/grad_sample/__init__.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 from .conv import compute_conv_grad_sample  # noqa
-from .dp_multihead_attention import compute_sequence_bias_grad_sample  # noqa
+from .dp_multihead_attention import (
+    compute_input_projection_grad_sample,
+    compute_sequence_bias_grad_sample,
+)  # noqa
 from .dp_rnn import compute_rnn_linear_grad_sample  # noqa
 from .embedding import compute_embedding_grad_sample  # noqa
 from .grad_sample_module import GradSampleModule, create_or_accumulate_grad_sample

--- a/opacus/grad_sample/dp_multihead_attention.py
+++ b/opacus/grad_sample/dp_multihead_attention.py
@@ -18,7 +18,7 @@ from typing import Dict
 
 import torch
 import torch.nn as nn
-from opacus.layers.dp_multihead_attention import SequenceBias
+from opacus.layers.dp_multihead_attention import InputProjection, SequenceBias
 
 from .utils import register_grad_sampler
 
@@ -36,3 +36,46 @@ def compute_sequence_bias_grad_sample(
         backprops: Backpropagations
     """
     return {layer.bias: backprops[:, -1]}
+
+
+@register_grad_sampler(InputProjection)
+def compute_input_projection_grad_sample(
+    layer: InputProjection, activations: torch.Tensor, backprops: torch.Tensor
+) -> Dict[nn.Parameter, torch.Tensor]:
+    """
+    Computes per sample gradients for ``InputProjection`` layer
+
+    Args:
+        layer: Layer
+        activations: Activations
+        backprops: Backpropagations
+    """
+    ret = {}
+
+    # TODO: since these calculations are taken from the linear module, perhaps they should
+    # be imported from there and reused between both methods?
+    def linear_weight_grad(activations: torch.Tensor, backprops: torch.Tensor):
+        return torch.einsum("n...i,n...j->nij", backprops, activations)
+
+    def linear_bias_grad(backprops: torch.Tensor):
+        return torch.einsum("n...k->nk", backprops)
+
+    q_bp, k_bp, v_bp = backprops.unbind(-1)
+
+    q_end_index = layer.qlinear_weight.shape[1]
+    k_end_index = q_end_index + layer.klinear_weight.shape[1]
+    q_a = activations[:, :, :q_end_index]
+    k_a = activations[:, :, q_end_index:k_end_index]
+    v_a = activations[:, :, k_end_index:]
+
+    ret[layer.qlinear_weight] = linear_weight_grad(q_a, q_bp)
+    ret[layer.klinear_weight] = linear_weight_grad(k_a, k_bp)
+    ret[layer.vlinear_weight] = linear_weight_grad(v_a, v_bp)
+
+    if layer.bias is not None:
+        ret[layer.bias] = torch.cat(
+            (linear_bias_grad(q_bp), linear_bias_grad(k_bp), linear_bias_grad(v_bp)),
+            axis=-1,
+        )
+
+    return ret

--- a/opacus/layers/__init__.py
+++ b/opacus/layers/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .dp_multihead_attention import DPMultiheadAttention, SequenceBias
+from .dp_multihead_attention import DPMultiheadAttention, InputProjection, SequenceBias
 from .dp_rnn import DPGRU, DPLSTM, DPRNN
 from .param_rename import RenameParamsMixin
 
@@ -23,6 +23,7 @@ __all__ = [
     "DPGRU",
     "DPLSTM",
     "DPMultiheadAttention",
+    "InputProjection",
     "RenameParamsMixin",
     "SequenceBias",
 ]

--- a/opacus/tests/grad_samples/input_projection_test.py
+++ b/opacus/tests/grad_samples/input_projection_test.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hypothesis.strategies as st
+import torch
+from hypothesis import given, settings
+from opacus.layers import InputProjection
+
+from .common import GradSampleHooks_test
+
+
+class InputProjection_test(GradSampleHooks_test):
+    @given(
+        embed_dim=st.integers(2, 4),
+        kdim=st.integers(2, 4),
+        vdim=st.integers(2, 4),
+        bias=st.booleans(),
+        batch_first=st.booleans(),
+    )
+    @settings(deadline=10000)
+    def test_invariance_to_shape_and_batch_ordering(
+        self, embed_dim: int, kdim: int, vdim: int, bias: bool, batch_first: bool
+    ):
+        input_projection = InputProjection(embed_dim, kdim, vdim, bias)
+        query = torch.randn([1, 1, embed_dim])
+        key = torch.randn([1, 1, kdim])
+        value = torch.randn([1, 1, vdim])
+        x = torch.cat((query, key, value), dim=-1)
+        self.run_test(x, input_projection, batch_first=batch_first)


### PR DESCRIPTION
Summary:
Three linear layers that were used to transform the inputs query, key and value respectively, were extracted to a dedicated module InputProjection.

In addition to the extraction refactoring, the nn.Linear modules used for the transformations were replaced with a bespoke operator parameterized by 4 tensors. That same operator is used in the reference module nn.MultiheadAttention. The modification will allow to match the states of nn.MultiheadAttention and opacus.DPMultiheadAttention.

Lastly, a custom gradient sampler was defined for the new module. This preserves the gradient sampling compatibility of the parent module - DPMultiheadAttention.

Differential Revision: D34850578

