### PR TITLE
Enable integration tests with the latest PyTorch by installing csprng from the source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Install PyTorch"
           command: |
-            pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu114
+            pip install torch torchvision torchaudio 
 
   lint_flake8:
     description: "Lint with flake8"
@@ -307,7 +307,8 @@ jobs:
   integrationtest_py37_torch_release_cuda:
     machine:
       resource_class: gpu.nvidia.small.multi
-      image: ubuntu-2004-cuda-11.4:202110-01
+      #image: ubuntu-2004-cuda-11.4:202110-01
+      image: ubuntu-1604-cuda-10.2:202012-01
     steps:
       - checkout
       - py_3_7_setup
@@ -328,7 +329,8 @@ jobs:
   unittest_multi_gpu:
     machine:
       resource_class: gpu.nvidia.medium.multi
-      image: ubuntu-2004-cuda-11.4:202110-01
+      #image: ubuntu-2004-cuda-11.4:202110-01
+      image: ubuntu-1604-cuda-10.2:202012-01
     steps:
       - checkout
       - py_3_7_setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Install PyTorch"
           command: |
-            pip install torch torchvision torchaudio
+            pip install torch==1.10.2 torchvision torchaudio
 
   lint_flake8:
     description: "Lint with flake8"
@@ -307,7 +307,7 @@ jobs:
   integrationtest_py37_torch_release_cuda:
     machine:
       resource_class: gpu.nvidia.small.multi
-      image: ubuntu-2004-cuda-11.2:202103-01
+      image: ubuntu-1604-cuda-10.2:202012-01
     steps:
       - checkout
       - py_3_7_setup
@@ -328,7 +328,7 @@ jobs:
   unittest_multi_gpu:
     machine:
       resource_class: gpu.nvidia.medium.multi
-      image: ubuntu-2004-cuda-11.2:202103-01
+      image: ubuntu-1604-cuda-10.2:202012-01
     steps:
       - checkout
       - py_3_7_setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Install PyTorch"
           command: |
-            pip install torch torchvision torchaudio 
+            pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
 
   lint_flake8:
     description: "Lint with flake8"
@@ -308,7 +308,7 @@ jobs:
     machine:
       resource_class: gpu.nvidia.small.multi
       #image: ubuntu-2004-cuda-11.4:202110-01
-      image: ubuntu-1604-cuda-10.2:202012-01
+      image: nvidia/cuda:11.3.1-base-ubuntu20.04
     steps:
       - checkout
       - py_3_7_setup
@@ -330,7 +330,7 @@ jobs:
     machine:
       resource_class: gpu.nvidia.medium.multi
       #image: ubuntu-2004-cuda-11.4:202110-01
-      image: ubuntu-1604-cuda-10.2:202012-01
+      image: nvidia/cuda:11.3.1-base-ubuntu20.04
     steps:
       - checkout
       - py_3_7_setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,14 @@ commands:
           name: "Install dependencies via pip"
           command: ./scripts/install_via_pip.sh << parameters.args >>
 
+  torch_cuda_install:
+    description: "Install PyTorch"
+    steps:
+      - run:
+          name: "Install PyTorch"
+          command: |
+            pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+
   lint_flake8:
     description: "Lint with flake8"
     steps:
@@ -303,6 +311,7 @@ jobs:
     steps:
       - checkout
       - py_3_7_setup
+      - torch_cuda_install
       - pip_dev_install
       - run_nvidia_smi
       - mnist_integration_test:
@@ -323,6 +332,7 @@ jobs:
     steps:
       - checkout
       - py_3_7_setup
+      - torch_cuda_install
       - pip_dev_install
       - run_nvidia_smi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,8 +307,7 @@ jobs:
   integrationtest_py37_torch_release_cuda:
     machine:
       resource_class: gpu.nvidia.small.multi
-      #image: ubuntu-2004-cuda-11.4:202110-01
-      image: nvidia/cuda:11.3.1-base-ubuntu20.04
+      image: ubuntu-2004-cuda-11.2:202103-01
     steps:
       - checkout
       - py_3_7_setup
@@ -329,8 +328,7 @@ jobs:
   unittest_multi_gpu:
     machine:
       resource_class: gpu.nvidia.medium.multi
-      #image: ubuntu-2004-cuda-11.4:202110-01
-      image: nvidia/cuda:11.3.1-base-ubuntu20.04
+      image: ubuntu-2004-cuda-11.2:202103-01
     steps:
       - checkout
       - py_3_7_setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
     steps:
       - run:
           name: "Install dependencies via pip"
-          command: ./scripts/install_via_pip.sh -v 1.8.1 << parameters.args >>
+          command: ./scripts/install_via_pip.sh << parameters.args >>
 
   lint_flake8:
     description: "Lint with flake8"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,14 +40,6 @@ commands:
           name: "Install dependencies via pip"
           command: ./scripts/install_via_pip.sh << parameters.args >>
 
-  torch_cuda_install:
-    description: "Install PyTorch"
-    steps:
-      - run:
-          name: "Install PyTorch"
-          command: |
-            pip install torch==1.10.2 torchvision torchaudio
-
   lint_flake8:
     description: "Lint with flake8"
     steps:
@@ -311,7 +303,6 @@ jobs:
     steps:
       - checkout
       - py_3_7_setup
-      - torch_cuda_install
       - pip_dev_install
       - run_nvidia_smi
       - mnist_integration_test:
@@ -332,7 +323,6 @@ jobs:
     steps:
       - checkout
       - py_3_7_setup
-      - torch_cuda_install
       - pip_dev_install
       - run_nvidia_smi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Install PyTorch"
           command: |
-            pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+            pip install torch torchvision torchaudio
 
   lint_flake8:
     description: "Lint with flake8"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
       - run:
           name: "Install PyTorch"
           command: |
-            pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+            pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu114
 
   lint_flake8:
     description: "Lint with flake8"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
-torch==1.8.1
-torchvision>=0.9.1
+torch
+torchvision
 tqdm>=4.40
 requests>=2.25.1
 black
@@ -9,7 +9,6 @@ sphinx
 sphinx-autodoc-typehints
 mypy>=0.760
 isort
-torchcsprng
 hypothesis
 tensorboard
 datasets
@@ -18,3 +17,4 @@ scikit-learn
 pytorch-lightning
 lightning-bolts
 jsonargparse[signatures]>=3.19.3 # required for Lightning CLI
+-e git+https://github.com/pytorch/csprng.git@cd8f2f670355f5a9b345dbe2cb58a52fb2c44d39#egg=torchcsprng

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -118,10 +118,11 @@ If you are getting an error like this, `ImportError: libcudart.so.10.2: cannot o
 
 The fix is to just install the package for the right Cuda version you have :)
 
-Here's the copypasta to install PyTorch with CUDA 10.1:
+Here's the copypasta to install PyTorch with CUDA 10.2:
 
 ```
-pip install torchcsprng==0.1.2+cu101 torch==1.6.0+cu101 torchvision==0.7.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
+pip3 install torch torchvision torchaudio
+pip install git+https://github.com/pytorch/csprng.git#egg=torchcsprng
 ```
 
 After this, you can just `pip install opacus` and it will work :)

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -46,7 +46,9 @@ export TERM=xterm
 # upgrade pip
 pip install --upgrade pip
 
-pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+if [[ $CUDA == true ]]; then
+  pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+fi
 
 # install without dependencies first
 # this is needed because csprng temporarily depends on the source

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -52,9 +52,9 @@ pip install -e .[dev] --user
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then
   if [[ $CUDA == true ]]; then
-    pip install --upgrade --pre torch torchvision torchcsprng -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
+    pip install --upgrade --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
   else
-    pip install --upgrade --pre torch torchvision torchcsprng -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    pip install --upgrade --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
   fi
 else
   # If no version specified, upgrade to latest release.

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -46,6 +46,11 @@ export TERM=xterm
 # upgrade pip
 pip install --upgrade pip
 
+# install without dependencies first
+# this is needed because csprng temporarily depends on the source
+# we need to have torch installed to correctly install .[dev]
+pip install -e . --user
+
 # install with dev dependencies
 pip install -e .[dev] --user
 

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -46,6 +46,8 @@ export TERM=xterm
 # upgrade pip
 pip install --upgrade pip
 
+pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
+
 # install without dependencies first
 # this is needed because csprng temporarily depends on the source
 # we need to have torch installed to correctly install .[dev]

--- a/scripts/pytorch_install.ps1
+++ b/scripts/pytorch_install.ps1
@@ -25,9 +25,4 @@ If ($TORCH_VERSION -eq "1.8.0") {
   $TORCHVISION_VERSION="0.10.1"
 }
 pip install torch==$TORCH_VERSION+cpu torchvision==$TORCHVISION_VERSION+cpu -f https://download.pytorch.org/whl/torch_stable.html
-
-If ($TORCH_VERSION -eq "1.8.0") {
-  pip install torchcsprng==$TORCHCSPRNG_VERSION+cpu -f https://download.pytorch.org/whl/torch_stable.html
-} Else {
-  echo "No torchcsprng"
-}
+pip install "git+https://github.com/pytorch/csprng.git@cd8f2f670355f5a9b345dbe2cb58a52fb2c44d39#egg=torchcsprng"

--- a/scripts/pytorch_install.ps1
+++ b/scripts/pytorch_install.ps1
@@ -25,4 +25,4 @@ If ($TORCH_VERSION -eq "1.8.0") {
   $TORCHVISION_VERSION="0.10.1"
 }
 pip install torch==$TORCH_VERSION+cpu torchvision==$TORCHVISION_VERSION+cpu -f https://download.pytorch.org/whl/torch_stable.html
-pip install "git+https://github.com/pytorch/csprng.git@cd8f2f670355f5a9b345dbe2cb58a52fb2c44d39#egg=torchcsprng"
+#pip install "git+https://github.com/pytorch/csprng.git@cd8f2f670355f5a9b345dbe2cb58a52fb2c44d39#egg=torchcsprng"

--- a/scripts/pytorch_install.sh
+++ b/scripts/pytorch_install.sh
@@ -35,4 +35,4 @@ pip install torch=="${TORCH_VERSION}"
 pip install torchvision==${TORCHVISION_VERSION}
 
 # torchcsprng
-pip install git+https://github.com/pytorch/csprng.git@cd8f2f670355f5a9b345dbe2cb58a52fb2c44d39#egg=torchcsprng
+#pip install git+https://github.com/pytorch/csprng.git@cd8f2f670355f5a9b345dbe2cb58a52fb2c44d39#egg=torchcsprng

--- a/scripts/pytorch_install.sh
+++ b/scripts/pytorch_install.sh
@@ -35,9 +35,4 @@ pip install torch=="${TORCH_VERSION}"
 pip install torchvision==${TORCHVISION_VERSION}
 
 # torchcsprng
-if [ "$TORCH_VERSION" = "1.8.0" ]
-then
-    pip install torchcsprng==${TORCHCSPRNG_VERSION}
-else
-    echo "No torchcsprng"
-fi
+pip install git+https://github.com/pytorch/csprng.git@cd8f2f670355f5a9b345dbe2cb58a52fb2c44d39#egg=torchcsprng

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@
 
 import os
 import sys
+import re
 
 from setuptools import find_packages, setup
 
@@ -55,7 +56,13 @@ with open("requirements.txt", encoding="utf8") as f:
     required = f.read().splitlines()
 
 with open("dev_requirements.txt", encoding="utf8") as f:
-    dev_required = f.read().splitlines()
+    dev_required = [
+        # This is to process correctly git repositories as dependencies
+        # https://stackoverflow.com/questions/32688688/how-to-write-setup-py-to-include-a-git-repository-as-a-dependency
+        re.sub(r'-e (git\+.*egg=(.*))', r'\2 @ \1', line)
+        for line in f.read().splitlines()
+    ]
+
 
 setup(
     name="opacus",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ with open("dev_requirements.txt", encoding="utf8") as f:
     dev_required = [
         # This is to process correctly git repositories as dependencies
         # https://stackoverflow.com/questions/32688688/how-to-write-setup-py-to-include-a-git-repository-as-a-dependency
-        re.sub(r'-e (git\+.*egg=(.*))', r'\2 @ \1', line)
+        re.sub(r"-e (git\+.*egg=(.*))", r"\2 @ \1", line)
         for line in f.read().splitlines()
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import os
-import sys
 import re
+import sys
 
 from setuptools import find_packages, setup
 


### PR DESCRIPTION
## Problem

Integration tests depends on [`csprng`](https://github.com/pytorch/csprng). The latest csprng release was made in Mar 2021 and has strict dependency on `pytorch==1.8.0` while the code actually works fine with the newer versions of pytorch.

The release cycle is currently broken and there is no easy way to make a new release with the fix.

## Temporary solution

Instead of installing `csprng` from PyPI (having outdated broken release), for the purpose of integration tests we install it from the github source. Recommend doing the same in FAQ. 

This removes artificially created dependency on the earlier pytorch version and unblocks new features.

## Further work

As agreed with the former csprng developer, the Opacus team is the new owner of [`csprng`](https://github.com/pytorch/csprng) repository. We are going to update and fix the release cycle. After that csprng can be pip installed without wrong dependencies.