### PR TITLE
Implementing 3D dilation

### DIFF
--- a/opacus/tests/grad_samples/conv3d_test.py
+++ b/opacus/tests/grad_samples/conv3d_test.py
@@ -34,7 +34,7 @@ class Conv3d_test(GradSampleHooks_test):
         kernel_size=st.sampled_from([2, 3, (1, 2, 3)]),
         stride=st.sampled_from([1, 2, (1, 2, 3)]),
         padding=st.sampled_from([0, 2, (1, 2, 3)]),
-        dilation=st.just(1),
+        dilation=st.sampled_from([1, (1, 2, 2)]),
         groups=st.integers(1, 16),
     )
     @settings(deadline=10000)


### PR DESCRIPTION
Summary:
Implemented 3D dilation for values that aren't `(1, 1, 1)` as requested by [this issue](https://github.com/pytorch/opacus/issues/182).

## The Algorithm
Algorithm works by dilating the kernel (see below) and then removing extraneous points after the tensor has been unfolded with the dilated kernel.  Removing extraneous points is done by calculating which rows/columns/etc. would have had zeros on them with the dilated kernel and removing them.

## Dilation
The dilated kernel size (for one dimension) is `kernel_size + (kernel_size - 1) * (dilation - 1)`. This is best explained through visualization (in 1D). Suppose we have a kernel that is 3 units long and we wish to dilate it by 3. Let `x` represent the units originally in the kernel and `o` represent the units introduced via dilation.

```
xooxoox
```

There are `kernel_size - 1` places to insert units from dilation and we want to insert `dilation - 1` units in each place. This leads to `(kernel_size - 1) * (dilation - 1)` total units from dilation and `kernel_size` original units, making a total `kernel_size + (kernel_size - 1) * (dilation - 1)` units.

Differential Revision: D35381703

