### PR TITLE
fix(batch_memory_manager): Ensures split_idxs use native python types.

### DIFF
--- a/opacus/utils/batch_memory_manager.py
+++ b/opacus/utils/batch_memory_manager.py
@@ -56,6 +56,7 @@ class BatchSplittingSampler(Sampler[List[int]]):
             split_idxs = np.array_split(
                 batch_idxs, math.ceil(len(batch_idxs) / self.max_batch_size)
             )
+            split_idxs = [s.tolist() for s in split_idxs]
             for x in split_idxs[:-1]:
                 self.optimizer.signal_skip_step(do_skip=True)
                 yield x


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

Ensures that `split_idxs` are passed forward using native Python types instead of Numpy-based types. (Issue #406)

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

`np.array_split` asserts that the output will be a list of Numpy arrays, with Numpy-based types (such as np.int64, np.float32, etc).

Unfortunately, there might be a chance that external resources (huggingface/datasets) use Python-native types and thus, the list of arrays needs to be mapped to a list of lists (which uses Python native types). Also, we need to traverse the list to perform such an operation.

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] The documentation is up-to-date with the changes I made.
- [X] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [X] All tests passed, and additional code has been covered with new tests.
