### PR TITLE
Support tied parameters

### DIFF
--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -351,7 +351,9 @@ class GradSampleModule(nn.Module):
         grad_sampler_fn = self.GRAD_SAMPLERS[type(module)]
         grad_samples = grad_sampler_fn(module, activations, backprops)
         for param, gs in grad_samples.items():
-            create_or_accumulate_grad_sample(param=param, grad_sample=gs, max_batch_len=module.max_batch_len)
+            create_or_accumulate_grad_sample(
+                param=param, grad_sample=gs, max_batch_len=module.max_batch_len
+            )
 
         for p in module.parameters():
             p._forward_counter -= 1

--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -355,6 +355,9 @@ class GradSampleModule(nn.Module):
                 param=param, grad_sample=gs, max_batch_len=module.max_batch_len
             )
 
+        # Detect end of current batch processing and switch accumulation
+        # mode from sum to stacking. Used for RNNs and tied parameters
+        # (See #417 for details)
         for p in module.parameters():
             p._forward_counter -= 1
             if p._forward_counter == 0:

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import warnings
 from typing import List, Optional, Tuple, Union
 
@@ -354,7 +353,10 @@ class PrivacyEngine:
         )
 
         sample_rate = 1 / len(data_loader)
-        expected_batch_size = int(len(data_loader.dataset) * sample_rate)
+        if getattr(data_loader, "batch_size", None):
+            expected_batch_size = data_loader.batch_size
+        else:
+            expected_batch_size = int(len(data_loader.dataset) * sample_rate)
 
         # expected_batch_size is the *per worker* batch size
         if distributed:

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -352,10 +352,11 @@ class PrivacyEngine:
             data_loader, distributed=distributed, poisson_sampling=poisson_sampling
         )
 
-        sample_rate = 1 / len(data_loader)
         if getattr(data_loader, "batch_size", None):
             expected_batch_size = data_loader.batch_size
+            sample_rate = expected_batch_size / len(data_loader.dataset)
         else:
+            sample_rate = 1 / len(data_loader)
             expected_batch_size = int(len(data_loader.dataset) * sample_rate)
 
         # expected_batch_size is the *per worker* batch size

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -352,12 +352,8 @@ class PrivacyEngine:
             data_loader, distributed=distributed, poisson_sampling=poisson_sampling
         )
 
-        if getattr(data_loader, "batch_size", None):
-            expected_batch_size = data_loader.batch_size
-            sample_rate = expected_batch_size / len(data_loader.dataset)
-        else:
-            sample_rate = 1 / len(data_loader)
-            expected_batch_size = int(len(data_loader.dataset) * sample_rate)
+        sample_rate = 1 / len(data_loader)
+        expected_batch_size = int(len(data_loader.dataset) * sample_rate)
 
         # expected_batch_size is the *per worker* batch size
         if distributed:

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -599,7 +599,7 @@ class PrivacyEngineConvNetTest(BasePrivacyEngineTest, unittest.TestCase):
                 [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
             ),
         )
-        return DataLoader(ds, batch_size=self.BATCH_SIZE)
+        return DataLoader(ds, batch_size=self.BATCH_SIZE, drop_last=True)
 
     def _init_model(
         self, private=False, state_dict=None, model=None, **privacy_engine_kwargs
@@ -674,7 +674,10 @@ class PrivacyEngineTextTest(BasePrivacyEngineTest, unittest.TestCase):
         y = torch.randint(0, 12, (self.DATA_SIZE,))
         ds = MockTextDataset(x, y)
         return DataLoader(
-            ds, batch_size=self.BATCH_SIZE, collate_fn=batch_second_collate
+            ds,
+            batch_size=self.BATCH_SIZE,
+            collate_fn=batch_second_collate,
+            drop_last=True,
         )
 
     def _init_model(
@@ -712,10 +715,10 @@ class SampleTiedWeights(nn.Module):
 class PrivacyEngineTiedWeightsTest(BasePrivacyEngineTest, unittest.TestCase):
     def _init_data(self):
         ds = TensorDataset(
-            torch.randint(low=0, high=100, size=(1000,)),
-            torch.randint(low=0, high=100, size=(1000,)),
+            torch.randint(low=0, high=100, size=(self.DATA_SIZE,)),
+            torch.randint(low=0, high=100, size=(self.DATA_SIZE,)),
         )
-        return DataLoader(ds, batch_size=self.BATCH_SIZE)
+        return DataLoader(ds, batch_size=self.BATCH_SIZE, drop_last=True)
 
     def _init_model(
         self, private=False, state_dict=None, model=None, **privacy_engine_kwargs


### PR DESCRIPTION
## Solution

As reported in #413, some models (including huggingface GPT-2) use tied parameters - i.e. sharing the same parameter between modules by simply using the same Parameter object. 
Opacus gets confused - it treats the second set of grad_samples as a new batch and accumulates them by stacking, which is obviously wrong. Conceptually this is not very different from RNNs, and the gradients should be simply added up.

Natural way to support this is to tweak the condition on which we distinguish between recurrent calls and new batch. Currently we look at module-level activations - if we've run out of the activations, it means that the recurrent calls are over and the next grad sample will be from a new batch. This obviously doesn't work for shared parameters - as the condition is module-level, but the parameter belong to multiple modules.

What we can do instead is to have parameter-level counters (`p._forward_counter`). This counter would increase on forward pass and decrease on backward. When it gets to zero, in would indicate that the latest backward pass is fully unrolled and we should expect new forward pass with the new data. If I understand correctly, we do not and should not allow multiple forwards or backwards in a row.

## Tests

I've added a new unit test for this and also checked Colab from the bug report - all seem to be working.