### PR TITLE
zero_grad() between forward and backward passes generates error message

### DIFF
--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -28,14 +28,22 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
 
 
-def forbid_accumulation_hook(module: GradSampleModule, _input: torch.Tensor):
+def forbid_accumulation_hook(module: GradSampleModule, _grad_input: torch.Tensor, _grad_output: torch.Tensor):
     """
-    Model hook, that detects repetitive forward/backward passes between optimizer
-    steps.
+    Model hook that detects repetitive forward/backward passes between optimizer steps.
+
+    This is a backward hook that will be wrapped around the whole model using
+    `register_full_backward_hook`. Hence, this hook will be *the first* to be called
+    among all backward hooks. In particular, it will be called *before* all hooks
+    present in the `autograd_grad_sample_hooks` attribute of `GradSampleModule`.
+    Hence, if `optimizer.zero_grad()` is not called before the backward hook and if
+    some `p.grad_sample` is not None, it means that `p.grad_sample` was updated in
+    a *previous* iteration.
 
     Args:
         module: input module
-        _input: module activations
+        _grad_input: module input gradient (not used here)
+        _grad_output: module output gradient (not used here)
 
     Raises:
         ValueError
@@ -346,7 +354,7 @@ class PrivacyEngine:
             module, batch_first=batch_first, loss_reduction=loss_reduction
         )
         if poisson_sampling:
-            module.register_forward_pre_hook(forbid_accumulation_hook)
+            module.register_full_backward_hook(forbid_accumulation_hook)
 
         data_loader = self._prepare_data_loader(
             data_loader, distributed=distributed, poisson_sampling=poisson_sampling


### PR DESCRIPTION
Summary:
In case of Poisson sampling, we must check that all `grad_sample` attributes are set to `None` (since we forbit accumulation with Poisson sampling).

This was previously done in a forward hook, resulting in an error message being thrown inadequately, in particular when `zero_grad()` is called between the forward and backward steps (see task for more context).

Hence, we instead register a backward hook at the `GradSampleModule` level (to ensure it's the first hook to be called, before the hooks that populate the `grad_sample` attribute). Updated the docstring accordingly with more details.

Differential Revision: D36067469

