### PR TITLE
Improve microbenchmark argument parsing and tests

### DIFF
--- a/benchmarks/benchmark_layer.py
+++ b/benchmarks/benchmark_layer.py
@@ -99,6 +99,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "layer",
+        type=str,
         choices=[v for k, v in LayerType.__dict__.items() if not k.startswith("__")],
     )
     parser.add_argument("--batch_size", default=64, type=int)
@@ -106,12 +107,18 @@ if __name__ == "__main__":
         "--num_repeats",
         default=20,
         type=int,
-        help="how many forward/backward passes to run",
+        help="number of forward/backward passes to run",
     )
     parser.add_argument(
         "--forward_only", action="store_true", help="only run forward passes"
     )
     parser.add_argument("--random_seed", default=0, type=int)
-    parser.add_argument("-c", "--config_file", type=str, default="config.json")
+    parser.add_argument(
+        "-c",
+        "--config_file",
+        default="config.json",
+        type=str,
+        help="path to config file with settings for each layer",
+    )
     args = parser.parse_args()
     main(args)

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -54,7 +54,7 @@ def run_and_save_benchmark(
             forward_only=args.forward_only,
             layer_name=layer,
             batch_size=batch_size,
-            random_seed=args.random_seed + i if args.random_seed else args.random_seed,
+            random_seed=args.random_seed + i if args.random_seed is not None else None,
             **layer_config,
         )
         res = {"runtime": runtime, "memory_stats": memory_stats}
@@ -144,7 +144,6 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--random_seed",
-        default=0,
         type=int,
         help="random seed for the first run for each layer and batch size, subsequent runs increase the random seed by 1",
     )

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -120,21 +120,24 @@ def main(args) -> None:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     layers = [v for k, v in LayerType.__dict__.items() if not k.startswith("__")]
-    parser.add_argument("--layers", choices=layers, default=layers, nargs="+")
+    parser.add_argument("--layers", nargs="+", default=layers, type=str, choices=layers)
     parser.add_argument(
         "--batch_sizes",
-        default=[16, 32, 64, 128, 256, 512],
         nargs="+",
+        default=[16, 32, 64, 128, 256, 512],
         type=int,
     )
     parser.add_argument(
-        "--num_runs", default=100, type=int, help="number of benchmarking runs"
+        "--num_runs",
+        default=100,
+        type=int,
+        help="number of benchmarking runs for each layer and batch size",
     )
     parser.add_argument(
         "--num_repeats",
         default=20,
         type=int,
-        help="how many forward/backward passes per run",
+        help="number of forward/backward passes per run",
     )
     parser.add_argument(
         "--forward_only", action="store_true", help="only run forward passes"
@@ -143,20 +146,29 @@ if __name__ == "__main__":
         "--random_seed",
         default=0,
         type=int,
-        help="random seed for the first run of each layer, subsequent runs increase the random seed by 1",
+        help="random seed for the first run for each layer and batch size, subsequent runs increase the random seed by 1",
     )
-    parser.add_argument("-c", "--config_file", type=str, default="config.json")
+    parser.add_argument(
+        "-c",
+        "--config_file",
+        default="config.json",
+        type=str,
+        help="path to config file with settings for each layer",
+    )
     parser.add_argument(
         "--cont", action="store_true", help="only run missing experiments"
     )
     parser.add_argument(
         "--root",
-        type=str,
         default="./results/raw/",
-        help="path to directory where benchmark results should be saved in",
+        type=str,
+        help="path to directory where benchmark results should be saved",
     )
     parser.add_argument(
-        "--suffix", type=str, help="suffix to append to each result file's name"
+        "--suffix",
+        default="",
+        type=str,
+        help="suffix to append to each result file's name",
     )
     parser.add_argument("--no_save", action="store_true")
     parser.add_argument("-v", "--verbose", action="store_true")

--- a/benchmarks/tests/test_benchmark_layer.py
+++ b/benchmarks/tests/test_benchmark_layer.py
@@ -14,7 +14,6 @@
 
 import math
 import time
-from itertools import product
 
 import pytest
 import torch
@@ -66,14 +65,9 @@ class FakeLayer(Layer):
         _ = self.forward_only()
 
 
-@pytest.mark.parametrize(
-    "duration, num_repeats, forward_only",
-    product(
-        [0, 0.005, 0.01, 0.05],
-        [10, 20, 50],
-        [False, True],
-    ),
-)
+@pytest.mark.parametrize("duration", [0, 0.005, 0.01, 0.05])
+@pytest.mark.parametrize("num_repeats", [10, 20, 50])
+@pytest.mark.parametrize("forward_only", [False, True])
 def test_runtime_benchmark(
     duration: float, num_repeats: int, forward_only: bool
 ) -> None:
@@ -98,15 +92,10 @@ def test_runtime_benchmark(
 
 
 @skipifnocuda
-@pytest.mark.parametrize(
-    "pass_bytes, layer_bytes, num_repeats, forward_only",
-    product(
-        [0, 1, 100, 500, 4096],
-        [0, 1, 256, 1024, 2000],
-        [10, 20, 50, 100],
-        [False, True],
-    ),
-)
+@pytest.mark.parametrize("pass_bytes", [0, 1, 100, 500, 4096])
+@pytest.mark.parametrize("layer_bytes", [0, 1, 256, 1024, 2000])
+@pytest.mark.parametrize("num_repeats", [10, 20, 50, 100])
+@pytest.mark.parametrize("forward_only", [False, True])
 def test_memory_benchmark(
     pass_bytes: int, layer_bytes: int, num_repeats: int, forward_only: bool
 ) -> None:
@@ -145,15 +134,10 @@ def test_memory_benchmark(
 
 
 @skipifnocuda
-@pytest.mark.parametrize(
-    "pass_bytes, layer_bytes, num_repeats, forward_only",
-    product(
-        [0, 1, 100, 500, 4096],
-        [0, 1, 256, 1024, 2000],
-        [10, 20, 50, 100],
-        [False, True],
-    ),
-)
+@pytest.mark.parametrize("pass_bytes", [0, 1, 100, 500, 4096])
+@pytest.mark.parametrize("layer_bytes", [0, 1, 256, 1024, 2000])
+@pytest.mark.parametrize("num_repeats", [10, 20, 50, 100])
+@pytest.mark.parametrize("forward_only", [False, True])
 def test_memory_benchmark_strict(
     pass_bytes: int, layer_bytes: int, num_repeats: int, forward_only: bool
 ) -> None:


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

### Fixes

- Suffix in `run_benchmarks.py` is assumed to be a string in `utils.get_path`. Now providing default value of empty string for `args.suffix` during argument parsing to avoid errors.
- Random seed of 0 (default) used to be treated as no random seed being given, this is now fixed. Accordingly removed the default value for`args.random_seed` during argument parsing.

### Refactors

- Reorder parameters for `ArgumentParser.add_argument` to enforce consistency, following the parameter order set in the [argparse docs](https://docs.python.org/3/library/argparse.html#the-add-argument-method).
- Improve type hints + help messages for argument parsing.
- Refactor `tests/test_benchmark_layer.py` without `itertools.product` for improved readability.


## How Has This Been Tested (if it applies) 

In benchmarks directory: 
```
python -m pytest tests
```

In root directory:
```
black .
flake8 --config ./.circleci/flake8_config.ini
isort -v -l 88 -o opacus --lines-after-imports 2 -m 3 --trailing-comma  .
```

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
