### PR TITLE
fix opacus nn.functional import (#901)

### DIFF
--- a/examples/imdb.py
+++ b/examples/imdb.py
@@ -22,10 +22,10 @@ import argparse
 import numpy as np
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.optim as optim
 from datasets import load_dataset
 from opacus import PrivacyEngine
-from torch.functional import F
 from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
 from tqdm import tqdm

--- a/opacus/utils/tensor_utils.py
+++ b/opacus/utils/tensor_utils.py
@@ -20,7 +20,7 @@ from typing import Iterator, List, Tuple, Union
 
 import numpy as np
 import torch
-from torch.functional import F
+import torch.nn.functional as F
 
 
 def calc_sample_norms(


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/benchmark/pull/901
Additional context: this change is necessitated by https://github.com/pytorch/pytorch/pull/73434, that replaces `import torch.nn.functional as F` with `import torch.nn.functional`, causing `from torch.functional import F` in opacus to no longer be valid.

per title

Differential Revision: D36172316

