### PR TITLE
Test Opacus with the latest PyTorch version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
     steps:
       - run:
           name: "Install dependencies via pip"
-          command: ./scripts/install_via_pip.sh -v 1.8.1 << parameters.args >>
+          command: ./scripts/install_via_pip.sh << parameters.args >>
 
   lint_flake8:
     description: "Lint with flake8"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -9,7 +9,6 @@ sphinx
 sphinx-autodoc-typehints
 mypy>=0.760
 isort
-torchcsprng
 hypothesis
 tensorboard
 datasets

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -465,11 +465,11 @@ class BasePrivacyEngineTest(ABC):
     @given(
         noise_multiplier=st.floats(0.5, 5.0),
         max_steps=st.integers(8, 10),
-        secure_mode=st.booleans(),
+        # secure_mode=st.booleans(),  # TODO: enable after fixing torchcsprng build
     )
     @settings(max_examples=20, deadline=None)
     def test_noise_level(
-        self, noise_multiplier: float, max_steps: int, secure_mode: bool
+        self, noise_multiplier: float, max_steps: int, secure_mode: bool = False
     ):
         """
         Tests that the noise level is correctly set
@@ -523,6 +523,7 @@ class BasePrivacyEngineTest(ABC):
             secure_mode=secure_mode,
         )
 
+    @unittest.skip("requires torchcsprng compatible with new pytorch versions")
     @patch("torch.normal", MagicMock(return_value=torch.Tensor([0.6])))
     def test_generate_noise_in_secure_mode(self):
         """

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -467,7 +467,7 @@ class BasePrivacyEngineTest(ABC):
         max_steps=st.integers(8, 10),
         secure_mode=st.just(False),   # TODO: enable after fixing torchcsprng build
     )
-    @settings(max_examples=20, deadline=None)
+    @settings(deadline=None)
     def test_noise_level(
         self, noise_multiplier: float, max_steps: int, secure_mode: bool
     ):

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -469,7 +469,7 @@ class BasePrivacyEngineTest(ABC):
     )
     @settings(max_examples=20, deadline=None)
     def test_noise_level(
-        self, noise_multiplier: float, max_steps: int, secure_mode: bool = False
+        self, noise_multiplier: float, max_steps: int, secure_mode: bool
     ):
         """
         Tests that the noise level is correctly set

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -465,7 +465,7 @@ class BasePrivacyEngineTest(ABC):
     @given(
         noise_multiplier=st.floats(0.5, 5.0),
         max_steps=st.integers(8, 10),
-        # secure_mode=st.booleans(),  # TODO: enable after fixing torchcsprng build
+        secure_mode=st.just(False),   # TODO: enable after fixing torchcsprng build
     )
     @settings(max_examples=20, deadline=None)
     def test_noise_level(

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -465,7 +465,7 @@ class BasePrivacyEngineTest(ABC):
     @given(
         noise_multiplier=st.floats(0.5, 5.0),
         max_steps=st.integers(8, 10),
-        secure_mode=st.just(False),   # TODO: enable after fixing torchcsprng build
+        secure_mode=st.just(False),  # TODO: enable after fixing torchcsprng build
     )
     @settings(deadline=None)
     def test_noise_level(

--- a/opacus/tests/randomness_test.py
+++ b/opacus/tests/randomness_test.py
@@ -329,6 +329,7 @@ class PrivacyEngineSecureModeTest(unittest.TestCase):
 
         self.assertTrue(torch.allclose(model1._module.weight, model2._module.weight))
 
+    @unittest.skip("requires torchcsprng compatible with new pytorch versions")
     def test_secure_mode_global_seed(self):
         model1, optim1, dl1 = self._init_dp_training(secure_mode=True)
         torch.manual_seed(1337)
@@ -403,6 +404,7 @@ class PrivacyEngineSecureModeTest(unittest.TestCase):
 
         self.assertTrue(torch.allclose(data1, data2))
 
+    @unittest.skip("requires torchcsprng compatible with new pytorch versions")
     def test_secure_mode_no_poisson(self):
         _, _, dl1 = self._init_dp_training(
             secure_mode=True, dl_seed=1337, poisson_sampling=False

--- a/opacus/tests/randomness_test.py
+++ b/opacus/tests/randomness_test.py
@@ -314,6 +314,7 @@ class PrivacyEngineSecureModeTest(unittest.TestCase):
 
         self.assertFalse(torch.allclose(model1._module.weight, model2._module.weight))
 
+    @unittest.skip("requires torchcsprng compatible with new pytorch versions")
     def test_raise_secure_mode(self):
         with self.assertRaises(ValueError):
             self._init_dp_training(secure_mode=True, noise_seed=42)

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -52,9 +52,9 @@ pip install -e .[dev] --user
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then
   if [[ $CUDA == true ]]; then
-    pip install --upgrade --pre torch torchvision torchcsprng -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
+    pip install --upgrade --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
   else
-    pip install --upgrade --pre torch torchvision torchcsprng -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    pip install --upgrade --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
   fi
 else
   # If no version specified, upgrade to latest release.

--- a/scripts/pytorch_install.ps1
+++ b/scripts/pytorch_install.ps1
@@ -16,7 +16,6 @@
 [string]$TORCH_VERSION=$args[0]
 If ($TORCH_VERSION -eq "1.8.0") {
   $TORCHVISION_VERSION="0.9.0"
-  $TORCHCSPRNG_VERSION="0.2.0"
 } Elseif ( $TORCH_VERSION -eq "1.8.1" ) {
   $TORCHVISION_VERSION="0.9.1"
 } Elseif ( $TORCH_VERSION -eq "1.9.0" ) {
@@ -26,8 +25,3 @@ If ($TORCH_VERSION -eq "1.8.0") {
 }
 pip install torch==$TORCH_VERSION+cpu torchvision==$TORCHVISION_VERSION+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
-If ($TORCH_VERSION -eq "1.8.0") {
-  pip install torchcsprng==$TORCHCSPRNG_VERSION+cpu -f https://download.pytorch.org/whl/torch_stable.html
-} Else {
-  echo "No torchcsprng"
-}

--- a/scripts/pytorch_install.sh
+++ b/scripts/pytorch_install.sh
@@ -19,7 +19,6 @@ TORCH_VERSION=$1
 if [ "$TORCH_VERSION" = "1.8.0" ]
 then
     TORCHVISION_VERSION="0.9.0"
-    TORCHCSPRNG_VERSION="0.2.0"
 elif [ "$TORCH_VERSION" = "1.8.1" ]
 then
     TORCHVISION_VERSION="0.9.1"
@@ -34,10 +33,3 @@ fi
 pip install torch=="${TORCH_VERSION}"
 pip install torchvision==${TORCHVISION_VERSION}
 
-# torchcsprng
-if [ "$TORCH_VERSION" = "1.8.0" ]
-then
-    pip install torchcsprng==${TORCHCSPRNG_VERSION}
-else
-    echo "No torchcsprng"
-fi


### PR DESCRIPTION
Temporarily removing dependency on `torchcsprng` (build is broken) and the corresponding tests to enable integration testing with the latest PyTorch version.

To roll back this after fixing [csprng](https://github.com/pytorch/csprng/) builds.