### PR TITLE
[RFC] Functorch to automatically compute per-sample gradients

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ commands:
             echo "Using $(python -V) ($(which python))"
             echo "Using $(pip -V) ($(which pip))"
             pip install --user datasets transformers
-            python examples/imdb.py --lr 0.02 --sigma 0.56 -c 1.0 --batch-size 32 --max-sequence-length 256 --epochs 1 --data-root runs/imdb/data --device <<parameters.device>>
+            python examples/imdb.py --lr 0.02 --sigma 1.0 -c 1.0 --batch-size 64 --max-sequence-length 256 --epochs 2 --data-root runs/imdb/data --device <<parameters.device>>
             python -c "import torch; accuracy = torch.load('run_results_imdb_classification.pt'); exit(0) if (accuracy>0.54 and accuracy<0.66) else exit(1)"
           when: always
       - store_test_results:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-torch==1.8.1
+torch
 torchvision>=0.9.1
 tqdm>=4.40
 requests>=2.25.1

--- a/opacus/grad_sample/functorch.py
+++ b/opacus/grad_sample/functorch.py
@@ -1,0 +1,60 @@
+from functorch import grad, make_functional, vmap
+from opacus.layers.dp_rnn import RNNLinear
+
+
+def prepare_layer(layer, batch_first=True):
+    """
+    Prepare a layer to compute grad samples using functorch.
+    The grad samples are computed by redoing the forward and
+    backward passes on the functional version of the module.
+
+    Args:
+        layer: the layer to prepare
+        batch_first: whether the input is batch_first or not
+    """
+    if len(list(layer.buffers())) > 0:
+        raise NotImplementedError(
+            "This layer has buffers and is not supported by Opacus"
+        )
+    flayer, _ = make_functional(layer)
+
+    def compute_loss_stateless_model(params, activations, backprops):
+        if batch_first or type(layer) is RNNLinear:
+            batched_activations = activations.unsqueeze(0)
+            batched_backprops = backprops.unsqueeze(0)
+        else:
+            # If batch_first is False, the batch dimension is the second dimension
+            batched_activations = activations.unsqueeze(1)
+            batched_backprops = backprops.unsqueeze(1)
+
+        output = flayer(params, batched_activations)
+        loss = (output * batched_backprops).sum()
+
+        return loss
+
+    ft_compute_grad = grad(compute_loss_stateless_model)
+    # Note that the vmap is done on the first dimension, regardless of batch_first
+    # This is because the activations and backprops given by the GradSampleModule
+    # are always batch_first=True
+    layer.ft_compute_sample_grad = vmap(ft_compute_grad, in_dims=(None, 0, 0))
+
+
+def ft_compute_per_sample_gradient(layer, activations, backprops):
+    """
+    Compute the per-sample gradient of the layer.
+    Args:
+        layer: the layer on which to compute the gradient
+        activations: the input to the layer
+        backprops: the  gradient of the loss w.r.t. outputs of the layer
+    """
+    parameters = list(layer.parameters())
+    if not hasattr(layer, "ft_compute_sample_grad"):
+        prepare_layer(layer)
+
+    per_sample_grads = layer.ft_compute_sample_grad(parameters, activations, backprops)
+
+    ret = {}
+    for i_p, p in enumerate(parameters):
+        ret[p] = per_sample_grads[i_p]
+
+    return ret

--- a/opacus/grad_sample/functorch.py
+++ b/opacus/grad_sample/functorch.py
@@ -1,4 +1,3 @@
-from functorch import grad, make_functional, vmap
 from opacus.layers.dp_rnn import RNNLinear
 
 
@@ -12,6 +11,8 @@ def prepare_layer(layer, batch_first=True):
         layer: the layer to prepare
         batch_first: whether the input is batch_first or not
     """
+    from functorch import grad, make_functional, vmap
+
     if len(list(layer.buffers())) > 0:
         raise NotImplementedError(
             "This layer has buffers and is not supported by Opacus"

--- a/opacus/grad_sample/utils.py
+++ b/opacus/grad_sample/utils.py
@@ -52,6 +52,8 @@ def register_grad_sampler(
 
 def wrap_model(model: nn.Module, grad_sample_mode: str, *args, **kwargs):
     cls = get_gsm_class(grad_sample_mode)
+    if grad_sample_mode == "functorch":
+        kwargs["force_functorch"] = True
     return cls(model, *args, **kwargs)
 
 
@@ -63,7 +65,7 @@ def get_gsm_class(grad_sample_mode: str) -> Type[AbstractGradSampleModule]:
     :param grad_sample_mode:
     :return:
     """
-    if grad_sample_mode == "hooks":
+    if grad_sample_mode in ["hooks", "functorch"]:
         return GradSampleModule
     elif grad_sample_mode == "ew":
         return GradSampleModuleExpandedWeights

--- a/opacus/tests/grad_sample_module_test.py
+++ b/opacus/tests/grad_sample_module_test.py
@@ -212,8 +212,9 @@ class GradSampleModuleTest(unittest.TestCase):
             def forward(self, x: torch.Tensor):
                 return F.linear(x, self.p)
 
-        with self.assertRaises(NotImplementedError):
-            GradSampleModule(SimpleLinear(4, 2))
+        # Should be handled by functorch
+        gsm = GradSampleModule(SimpleLinear(4, 2))
+        self.assertTrue(hasattr(gsm._module, "ft_compute_sample_grad"))
 
         # Should not raise exception if strict=False
         GradSampleModule(SimpleLinear(4, 2), strict=False)
@@ -225,9 +226,6 @@ class GradSampleModuleTest(unittest.TestCase):
     def test_custom_module_validation(self):
         with self.assertRaises(NotImplementedError):
             GradSampleModule(mobilenet_v3_small())
-
-        # Should not raise exception if strict=False
-        GradSampleModule(mobilenet_v3_small(), strict=False)
 
     def test_submodule_access(self):
         _ = self.grad_sample_module.fc1

--- a/opacus/tests/grad_sample_module_test.py
+++ b/opacus/tests/grad_sample_module_test.py
@@ -213,11 +213,17 @@ class GradSampleModuleTest(unittest.TestCase):
                 return F.linear(x, self.p)
 
         # Should be handled by functorch
-        gsm = GradSampleModule(SimpleLinear(4, 2))
-        self.assertTrue(hasattr(gsm._module, "ft_compute_sample_grad"))
+        try:
+            gsm = GradSampleModule(SimpleLinear(4, 2))
+            self.assertTrue(hasattr(gsm._module, "ft_compute_sample_grad"))
+        except ImportError:
+            print("Test could not be ran because functorch not available")
 
         # Should not raise exception if strict=False
-        GradSampleModule(SimpleLinear(4, 2), strict=False)
+        try:
+            GradSampleModule(SimpleLinear(4, 2), strict=False)
+        except ImportError:
+            print("Test could not be ran because functorch not available")
 
         # Should not fail after relevant grad sampler has been registered
         register_grad_sampler(SimpleLinear)(compute_linear_grad_sample)

--- a/opacus/tests/grad_samples/common.py
+++ b/opacus/tests/grad_samples/common.py
@@ -222,7 +222,7 @@ class GradSampleHooks_test(unittest.TestCase):
     ):
         grad_sample_modes = ["hooks", "functorch"]
         try:
-            import functorch
+            import functorch  # noqa
         except ImportError:
             grad_sample_modes = ["hooks"]
 

--- a/opacus/tests/grad_samples/common.py
+++ b/opacus/tests/grad_samples/common.py
@@ -220,8 +220,13 @@ class GradSampleHooks_test(unittest.TestCase):
         rtol=10e-5,
         ew_compatible=True,
     ):
+        grad_sample_modes = ["hooks", "functorch"]
+        try:
+            import functorch
+        except ImportError:
+            grad_sample_modes = ["hooks"]
 
-        for grad_sample_mode in ["hooks", "functorch"]:
+        for grad_sample_mode in grad_sample_modes:
             for loss_reduction in ["sum", "mean"]:
 
                 with self.subTest(
@@ -253,7 +258,6 @@ class GradSampleHooks_test(unittest.TestCase):
         module: nn.Module,
         batch_first=True,
         loss_reduction="mean",
-        force_functorch=False,
         atol=10e-6,
         rtol=10e-5,
         grad_sample_mode="hooks",

--- a/opacus/tests/grad_samples/common.py
+++ b/opacus/tests/grad_samples/common.py
@@ -220,34 +220,23 @@ class GradSampleHooks_test(unittest.TestCase):
         rtol=10e-5,
         ew_compatible=True,
     ):
-        self.run_test_with_reduction(
-            x,
-            module,
-            batch_first=batch_first,
-            loss_reduction="mean",
-            atol=atol,
-            rtol=rtol,
-            grad_sample_mode="hooks",
-        )
-        self.run_test_with_reduction(
-            x,
-            module,
-            batch_first=batch_first,
-            loss_reduction="sum",
-            atol=atol,
-            rtol=rtol,
-            grad_sample_mode="hooks",
-        )
+
+        for grad_sample_mode in ["hooks", "functorch"]:
+            for loss_reduction in ["sum", "mean"]:
+
+                with self.subTest(
+                    grad_sample_mode=grad_sample_mode, loss_reduction=loss_reduction
+                ):
+                    self.run_test_with_reduction(
+                        x,
+                        module,
+                        batch_first=batch_first,
+                        loss_reduction=loss_reudction,
+                        atol=atol,
+                        rtol=rtol,
+                        grad_sample_mode=grad_sample_mode,
+                    )
         if ew_compatible and batch_first and torch.__version__ >= (1, 13):
-            self.run_test_with_reduction(
-                x,
-                module,
-                batch_first=batch_first,
-                loss_reduction="mean",
-                atol=atol,
-                rtol=rtol,
-                grad_sample_mode="ew",
-            )
             self.run_test_with_reduction(
                 x,
                 module,
@@ -264,6 +253,7 @@ class GradSampleHooks_test(unittest.TestCase):
         module: nn.Module,
         batch_first=True,
         loss_reduction="mean",
+        force_functorch=False,
         atol=10e-6,
         rtol=10e-5,
         grad_sample_mode="hooks",

--- a/opacus/tests/grad_samples/common.py
+++ b/opacus/tests/grad_samples/common.py
@@ -231,7 +231,7 @@ class GradSampleHooks_test(unittest.TestCase):
                         x,
                         module,
                         batch_first=batch_first,
-                        loss_reduction=loss_reudction,
+                        loss_reduction=loss_reduction,
                         atol=atol,
                         rtol=rtol,
                         grad_sample_mode=grad_sample_mode,

--- a/opacus/tests/grad_samples/conv1d_test.py
+++ b/opacus/tests/grad_samples/conv1d_test.py
@@ -48,7 +48,6 @@ class Conv1d_test(GradSampleHooks_test):
         dilation: int,
         groups: int,
     ):
-
         out_channels = out_channels_mapper(C)
         if (
             C % groups != 0 or out_channels % groups != 0

--- a/opacus/tests/module_validator_test.py
+++ b/opacus/tests/module_validator_test.py
@@ -65,7 +65,6 @@ class ModuleValidator_test(unittest.TestCase):
                 return x
 
         model = SampleNetWithExtraParam()
-
         # ModelValidator no longer checks for supported modules
         self.assertTrue(ModuleValidator.is_valid(model))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+functorch
 numpy>=1.15
 torch>=1.8
 scipy>=1.2


### PR DESCRIPTION
**TL;DR** We can use Functorch to compute per sample gradients automatically.

This PR proposes to use Functorch to compute per sample gradients. The "meat" is in grad_sample/functorch.py. It basically does a mini-"per sample" forward/backward on the layer at hand, with the tricks that outputs.backward(backprops) is equivalent to (outputs * backprops).sum().backward().


## Open questions

1. How do we validate the modules? It used to be clear that any module which grad_sampler was not implemented was not OK but now it's different. Should we move from a model where everything not allowed was forbidden, to a model where everything not forbidden is allowed.
2. Do we want to provide clean support for activation/de-activation of GRAD_SAMPLERS or is it ok to just del GRAD_SAMPLERS[module]? 