### PR TITLE
new ExpandedWeights API

### DIFF
--- a/opacus/grad_sample/__init__.py
+++ b/opacus/grad_sample/__init__.py
@@ -20,7 +20,10 @@ from .embedding import compute_embedding_grad_sample  # noqa
 from .grad_sample_module import GradSampleModule, create_or_accumulate_grad_sample
 from .group_norm import compute_group_norm_grad_sample  # noqa
 from .gsm_base import AbstractGradSampleModule
-from .gsm_exp_weights import GradSampleModuleExpandedWeights
+from .gsm_exp_weights import (
+    COMPATIBILITY_API_CUTOFF_VERSION,
+    GradSampleModuleExpandedWeights,
+)
 from .instance_norm import compute_instance_norm_grad_sample  # noqa
 from .layer_norm import compute_layer_norm_grad_sample  # noqa
 from .linear import compute_linear_grad_sample  # noqa
@@ -35,4 +38,5 @@ __all__ = [
     "create_or_accumulate_grad_sample",
     "wrap_model",
     "get_gsm_class",
+    "COMPATIBILITY_API_CUTOFF_VERSION",
 ]

--- a/opacus/grad_sample/gsm_exp_weights.py
+++ b/opacus/grad_sample/gsm_exp_weights.py
@@ -51,5 +51,5 @@ class GradSampleModuleExpandedWeights(AbstractGradSampleModule):
             )(x, *args, **kwargs)
         else:
             return self.call_for_per_sample_grads(
-                self._module, x.shape[0], x, *args, **kwargs
+                module=self._module, batch_size=x.shape[0], args=(x, *args), **kwargs
             )

--- a/opacus/grad_sample/gsm_exp_weights.py
+++ b/opacus/grad_sample/gsm_exp_weights.py
@@ -3,6 +3,9 @@ import torch.nn as nn
 from opacus.grad_sample.gsm_base import AbstractGradSampleModule
 
 
+COMPATIBILITY_API_CUTOFF_VERSION = "1.13.0.dev"
+
+
 class GradSampleModuleExpandedWeights(AbstractGradSampleModule):
     """
     ExpandedWeights-based implementation of AbstractGradSampleModule
@@ -40,6 +43,13 @@ class GradSampleModuleExpandedWeights(AbstractGradSampleModule):
         )
 
     def forward(self, x: torch.Tensor, *args, **kwargs):
-        return self.call_for_per_sample_grads(
-            self._module, x.shape[0], x, *args, **kwargs
-        )
+        if torch.__version__ >= COMPATIBILITY_API_CUTOFF_VERSION:
+            return self.call_for_per_sample_grads(
+                module=self._module,
+                batch_size=x.shape[0],
+                loss_reduction=self.loss_reduction,
+            )(x, *args, **kwargs)
+        else:
+            return self.call_for_per_sample_grads(
+                self._module, x.shape[0], x, *args, **kwargs
+            )

--- a/opacus/grad_sample/gsm_exp_weights.py
+++ b/opacus/grad_sample/gsm_exp_weights.py
@@ -51,5 +51,5 @@ class GradSampleModuleExpandedWeights(AbstractGradSampleModule):
             )(x, *args, **kwargs)
         else:
             return self.call_for_per_sample_grads(
-                self._module, x.shape[0], x, *args, **kwargs
+                module=self._module, batch_size=x.shape[0], x, *args, **kwargs
             )

--- a/opacus/grad_sample/gsm_exp_weights.py
+++ b/opacus/grad_sample/gsm_exp_weights.py
@@ -51,5 +51,5 @@ class GradSampleModuleExpandedWeights(AbstractGradSampleModule):
             )(x, *args, **kwargs)
         else:
             return self.call_for_per_sample_grads(
-                module=self._module, batch_size=x.shape[0], x, *args, **kwargs
+                self._module, x.shape[0], x, *args, **kwargs
             )

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -37,7 +37,14 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
 
 
-def _is_ew_compatibility_required(grad_sample_mode: str):
+def _is_ew_compatibility_check_required(grad_sample_mode: str):
+    """
+    ExpandedWeights is still in the experimental phase with a fast-evolving API.
+    For this reason (see #453 for details) we need different handling depending on the
+    PyTorch version.
+    Special handling only required for PyTorch < 1.13 and if `grad_sample_mode=ew`
+    is enabled
+    """
     return (
         grad_sample_mode == "ew"
         and torch.__version__ < COMPATIBILITY_API_CUTOFF_VERSION
@@ -187,7 +194,7 @@ class PrivacyEngine:
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=self.secure_mode,
-            ew_compatibility_mode=_is_ew_compatibility_required(grad_sample_mode),
+            ew_compatibility_mode=_is_ew_compatibility_check_required(grad_sample_mode),
         )
 
     def _prepare_data_loader(


### PR DESCRIPTION
as ExpandedWeights are still in beta phase, breaking changes are expected (e.g. [#80892](https://github.com/pytorch/pytorch/pull/80892)).

See also [test failures](https://app.circleci.com/pipelines/github/pytorch/opacus/2047/workflows/09923631-5734-443b-b639-817f372f8f64/jobs/11263) that only manifest on nightly PyTorch build.

This is a temporary solution - eventually, when enough people have migrated past torch==1.12 we only want to keep current (1.13+) API imtegration