### PR TITLE
More goodness from ExpandedWeights

### DIFF
--- a/opacus/grad_sample/README.md
+++ b/opacus/grad_sample/README.md
@@ -44,7 +44,7 @@ Please note that these are known limitations and we plan to improve Expanded Wei
 
 | xxx | Hooks | Expanded Weights |
 |:-----:|:-------:|:------------------:|
-| Required PyTorch version | 1.8+ | 1.12+ |
+| Required PyTorch version | 1.8+ | 1.13+ |
 | Development status | Underlying mechanism deprecated | Beta |
 | Performance | - | ✅ Likely up to 2.5x faster |
 | torchscript models | Not supported | ✅ Supported |
@@ -52,5 +52,3 @@ Please note that these are known limitations and we plan to improve Expanded Wei
 | `batch_first=False` | ✅ Supported | Not supported |
 | Most popular nn.* layers | ✅ Supported | ✅ Supported |
 | Recurrent networks | ✅ Supported | Not supported |
-| nn.LayerNorm | ✅ Supported | ⚠️ Unstable |
-| nn.Conv3d | ✅ Supported | Not supported |

--- a/opacus/grad_sample/__init__.py
+++ b/opacus/grad_sample/__init__.py
@@ -21,7 +21,6 @@ from .grad_sample_module import GradSampleModule, create_or_accumulate_grad_samp
 from .group_norm import compute_group_norm_grad_sample  # noqa
 from .gsm_base import AbstractGradSampleModule
 from .gsm_exp_weights import (
-    COMPATIBILITY_API_CUTOFF_VERSION,
     GradSampleModuleExpandedWeights,
 )
 from .instance_norm import compute_instance_norm_grad_sample  # noqa
@@ -38,5 +37,4 @@ __all__ = [
     "create_or_accumulate_grad_sample",
     "wrap_model",
     "get_gsm_class",
-    "COMPATIBILITY_API_CUTOFF_VERSION",
 ]

--- a/opacus/grad_sample/__init__.py
+++ b/opacus/grad_sample/__init__.py
@@ -20,9 +20,7 @@ from .embedding import compute_embedding_grad_sample  # noqa
 from .grad_sample_module import GradSampleModule, create_or_accumulate_grad_sample
 from .group_norm import compute_group_norm_grad_sample  # noqa
 from .gsm_base import AbstractGradSampleModule
-from .gsm_exp_weights import (
-    GradSampleModuleExpandedWeights,
-)
+from .gsm_exp_weights import GradSampleModuleExpandedWeights
 from .instance_norm import compute_instance_norm_grad_sample  # noqa
 from .layer_norm import compute_layer_norm_grad_sample  # noqa
 from .linear import compute_linear_grad_sample  # noqa

--- a/opacus/grad_sample/gsm_exp_weights.py
+++ b/opacus/grad_sample/gsm_exp_weights.py
@@ -26,6 +26,7 @@ class GradSampleModuleExpandedWeights(AbstractGradSampleModule):
 
         if torch.__version__ >= API_CUTOFF_VERSION:
             from torch.nn.utils._per_sample_grad import call_for_per_sample_grads
+
             self.call_for_per_sample_grads = call_for_per_sample_grads
         else:
             raise ImportError(

--- a/opacus/grad_sample/gsm_exp_weights.py
+++ b/opacus/grad_sample/gsm_exp_weights.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 from opacus.grad_sample.gsm_base import AbstractGradSampleModule
 
 
-COMPATIBILITY_API_CUTOFF_VERSION = "1.13.0.dev"
+API_CUTOFF_VERSION = "1.13.0.dev"
 
 
 class GradSampleModuleExpandedWeights(AbstractGradSampleModule):
@@ -24,11 +24,10 @@ class GradSampleModuleExpandedWeights(AbstractGradSampleModule):
         if not batch_first:
             raise NotImplementedError
 
-        try:
+        if torch.__version__ >= API_CUTOFF_VERSION:
             from torch.nn.utils._per_sample_grad import call_for_per_sample_grads
-
             self.call_for_per_sample_grads = call_for_per_sample_grads
-        except ImportError:
+        else:
             raise ImportError(
                 f"Requested grad_sample_mode=ew, "
                 f"but found PyTorch version={torch.__version__}. "
@@ -43,13 +42,8 @@ class GradSampleModuleExpandedWeights(AbstractGradSampleModule):
         )
 
     def forward(self, x: torch.Tensor, *args, **kwargs):
-        if torch.__version__ >= COMPATIBILITY_API_CUTOFF_VERSION:
-            return self.call_for_per_sample_grads(
-                module=self._module,
-                batch_size=x.shape[0],
-                loss_reduction=self.loss_reduction,
-            )(x, *args, **kwargs)
-        else:
-            return self.call_for_per_sample_grads(
-                module=self._module, batch_size=x.shape[0], args=(x, *args), **kwargs
-            )
+        return self.call_for_per_sample_grads(
+            module=self._module,
+            batch_size=x.shape[0],
+            loss_reduction=self.loss_reduction,
+        )(x, *args, **kwargs)

--- a/opacus/optimizers/adaclipoptimizer.py
+++ b/opacus/optimizers/adaclipoptimizer.py
@@ -54,7 +54,6 @@ class AdaClipDPOptimizer(DPOptimizer):
         loss_reduction: str = "mean",
         generator=None,
         secure_mode: bool = False,
-        ew_compatibility_mode=False,
     ):
         super().__init__(
             optimizer,
@@ -64,7 +63,6 @@ class AdaClipDPOptimizer(DPOptimizer):
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=secure_mode,
-            ew_compatibility_mode=ew_compatibility_mode,
         )
         assert (
             max_clipbound > min_clipbound

--- a/opacus/optimizers/ddp_perlayeroptimizer.py
+++ b/opacus/optimizers/ddp_perlayeroptimizer.py
@@ -49,7 +49,6 @@ class SimpleDistributedPerLayerOptimizer(DPPerLayerOptimizer, DistributedDPOptim
         loss_reduction: str = "mean",
         generator=None,
         secure_mode: bool = False,
-        ew_compatibility_mode=False,
     ):
         self.rank = torch.distributed.get_rank()
         self.world_size = torch.distributed.get_world_size()
@@ -62,7 +61,6 @@ class SimpleDistributedPerLayerOptimizer(DPPerLayerOptimizer, DistributedDPOptim
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=secure_mode,
-            ew_compatibility_mode=ew_compatibility_mode,
         )
 
 
@@ -82,7 +80,6 @@ class DistributedPerLayerOptimizer(DPOptimizer):
         loss_reduction: str = "mean",
         generator=None,
         secure_mode: bool = False,
-        ew_compatibility_mode=False,
     ):
         self.rank = torch.distributed.get_rank()
         self.world_size = torch.distributed.get_world_size()
@@ -96,7 +93,6 @@ class DistributedPerLayerOptimizer(DPOptimizer):
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=secure_mode,
-            ew_compatibility_mode=ew_compatibility_mode,
         )
         self._register_hooks()
 

--- a/opacus/optimizers/ddpoptimizer.py
+++ b/opacus/optimizers/ddpoptimizer.py
@@ -38,7 +38,6 @@ class DistributedDPOptimizer(DPOptimizer):
         loss_reduction: str = "mean",
         generator=None,
         secure_mode: bool = False,
-        ew_compatibility_mode=False,
     ):
         super().__init__(
             optimizer,
@@ -48,7 +47,6 @@ class DistributedDPOptimizer(DPOptimizer):
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=secure_mode,
-            ew_compatibility_mode=ew_compatibility_mode,
         )
         self.rank = torch.distributed.get_rank()
         self.world_size = torch.distributed.get_world_size()

--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -204,7 +204,6 @@ class DPOptimizer(Optimizer):
         loss_reduction: str = "mean",
         generator=None,
         secure_mode: bool = False,
-        ew_compatibility_mode=False,
     ):
         """
 
@@ -246,7 +245,6 @@ class DPOptimizer(Optimizer):
         self.state = self.original_optimizer.state
         self._step_skip_queue = []
         self._is_last_step_skipped = False
-        self.ew_compatibility_mode = ew_compatibility_mode
 
         for p in self.params:
             p.summed_grad = None
@@ -291,10 +289,7 @@ class DPOptimizer(Optimizer):
         else:
             raise ValueError(f"Unexpected grad_sample type: {type(p.grad_sample)}")
 
-        if self.ew_compatibility_mode and self.loss_reduction == "mean":
-            return ret * len(ret)
-        else:
-            return ret
+        return ret
 
     def signal_skip_step(self, do_skip=True):
         """

--- a/opacus/optimizers/perlayeroptimizer.py
+++ b/opacus/optimizers/perlayeroptimizer.py
@@ -40,7 +40,6 @@ class DPPerLayerOptimizer(DPOptimizer):
         loss_reduction: str = "mean",
         generator=None,
         secure_mode: bool = False,
-        ew_compatibility_mode=False,
     ):
         assert len(max_grad_norm) == len(params(optimizer))
         self.max_grad_norms = max_grad_norm
@@ -53,7 +52,6 @@ class DPPerLayerOptimizer(DPOptimizer):
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=secure_mode,
-            ew_compatibility_mode=ew_compatibility_mode,
         )
 
     def clip_and_accumulate(self):

--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -22,7 +22,6 @@ from opacus.accountants.utils import get_noise_multiplier
 from opacus.data_loader import DPDataLoader, switch_generator
 from opacus.distributed import DifferentiallyPrivateDistributedDataParallel as DPDDP
 from opacus.grad_sample import (
-    COMPATIBILITY_API_CUTOFF_VERSION,
     AbstractGradSampleModule,
     GradSampleModule,
     get_gsm_class,
@@ -35,20 +34,6 @@ from opacus.validators.module_validator import ModuleValidator
 from torch import nn, optim
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
-
-
-def _is_ew_compatibility_check_required(grad_sample_mode: str):
-    """
-    ExpandedWeights is still in the experimental phase with a fast-evolving API.
-    For this reason (see #453 for details) we need different handling depending on the
-    PyTorch version.
-    Special handling only required for PyTorch < 1.13 and if `grad_sample_mode=ew`
-    is enabled
-    """
-    return (
-        grad_sample_mode == "ew"
-        and torch.__version__ < COMPATIBILITY_API_CUTOFF_VERSION
-    )
 
 
 def forbid_accumulation_hook(
@@ -194,7 +179,6 @@ class PrivacyEngine:
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=self.secure_mode,
-            ew_compatibility_mode=_is_ew_compatibility_check_required(grad_sample_mode),
         )
 
     def _prepare_data_loader(

--- a/opacus/tests/batch_memory_manager_test.py
+++ b/opacus/tests/batch_memory_manager_test.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from opacus import PrivacyEngine
+from opacus.grad_sample.gsm_exp_weights import API_CUTOFF_VERSION
 from opacus.utils.batch_memory_manager import BatchMemoryManager
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -168,6 +169,8 @@ class BatchMemoryManagerTest(unittest.TestCase):
         self.assertTrue(torch.allclose(memory_manager_weights, vanilla_weights))
 
 
-@unittest.skipIf(torch.__version__ < (1, 12), "not supported in this torch version")
+@unittest.skipIf(
+    torch.__version__ < API_CUTOFF_VERSION, "not supported in this torch version"
+)
 class BatchMemoryManagerTestWithExpandedWeights(BatchMemoryManagerTest):
     GSM_MODE = "ew"

--- a/opacus/tests/grad_sample_module_test.py
+++ b/opacus/tests/grad_sample_module_test.py
@@ -19,7 +19,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from opacus.grad_sample import GradSampleModule
-from opacus.grad_sample.gsm_exp_weights import GradSampleModuleExpandedWeights
+from opacus.grad_sample.gsm_exp_weights import (
+    API_CUTOFF_VERSION,
+    GradSampleModuleExpandedWeights,
+)
 from opacus.grad_sample.linear import compute_linear_grad_sample
 from opacus.grad_sample.utils import register_grad_sampler
 from torch.testing import assert_allclose
@@ -255,7 +258,9 @@ class GradSampleModuleTest(unittest.TestCase):
             )
 
 
-@unittest.skipIf(torch.__version__ < (1, 12), "not supported in this torch version")
+@unittest.skipIf(
+    torch.__version__ < API_CUTOFF_VERSION, "not supported in this torch version"
+)
 class EWGradSampleModuleTest(GradSampleModuleTest):
     CLS = GradSampleModuleExpandedWeights
 

--- a/opacus/tests/grad_samples/common.py
+++ b/opacus/tests/grad_samples/common.py
@@ -238,7 +238,16 @@ class GradSampleHooks_test(unittest.TestCase):
             rtol=rtol,
             grad_sample_mode="hooks",
         )
-        if ew_compatible and batch_first and torch.__version__ >= (1, 12):
+        if ew_compatible and batch_first and torch.__version__ >= (1, 13):
+            self.run_test_with_reduction(
+                x,
+                module,
+                batch_first=batch_first,
+                loss_reduction="mean",
+                atol=atol,
+                rtol=rtol,
+                grad_sample_mode="ew",
+            )
             self.run_test_with_reduction(
                 x,
                 module,

--- a/opacus/tests/grad_samples/conv3d_test.py
+++ b/opacus/tests/grad_samples/conv3d_test.py
@@ -68,6 +68,7 @@ class Conv3d_test(GradSampleHooks_test):
             dilation=dilation,
             groups=groups,
         )
+        is_ew_compatible = (dilation==1)
         self.run_test(
-            x, conv, batch_first=True, atol=10e-5, rtol=10e-3, ew_compatible=False
+            x, conv, batch_first=True, atol=10e-5, rtol=10e-3, ew_compatible=is_ew_compatible
         )

--- a/opacus/tests/grad_samples/conv3d_test.py
+++ b/opacus/tests/grad_samples/conv3d_test.py
@@ -68,7 +68,12 @@ class Conv3d_test(GradSampleHooks_test):
             dilation=dilation,
             groups=groups,
         )
-        is_ew_compatible = (dilation==1)
+        is_ew_compatible = dilation == 1
         self.run_test(
-            x, conv, batch_first=True, atol=10e-5, rtol=10e-3, ew_compatible=is_ew_compatible
+            x,
+            conv,
+            batch_first=True,
+            atol=10e-5,
+            rtol=10e-3,
+            ew_compatible=is_ew_compatible,
         )

--- a/opacus/tests/grad_samples/layer_norm_test.py
+++ b/opacus/tests/grad_samples/layer_norm_test.py
@@ -64,4 +64,4 @@ class LayerNorm_test(GradSampleHooks_test):
 
         norm = nn.LayerNorm(normalized_shape, elementwise_affine=True)
         x = torch.randn(x_shape)
-        self.run_test(x, norm, batch_first=True, ew_compatible=False)
+        self.run_test(x, norm, batch_first=True)

--- a/opacus/tests/module_validator_test.py
+++ b/opacus/tests/module_validator_test.py
@@ -49,7 +49,8 @@ class ModuleValidator_test(unittest.TestCase):
 
     def test_is_valid_unsupported_grdsample_module(self):
         unsupported_module = nn.Bilinear(2, 2, 2)  # currently not implemented
-        self.assertFalse(ModuleValidator.is_valid(unsupported_module))
+        # ModelValidator no longer checks for supported modules
+        self.assertTrue(ModuleValidator.is_valid(unsupported_module))
 
     def test_is_valid_extra_param(self):
         class SampleNetWithExtraParam(nn.Module):
@@ -64,7 +65,9 @@ class ModuleValidator_test(unittest.TestCase):
                 return x
 
         model = SampleNetWithExtraParam()
-        self.assertFalse(ModuleValidator.is_valid(model))
+
+        # ModelValidator no longer checks for supported modules
+        self.assertTrue(ModuleValidator.is_valid(model))
 
         model.extra_param.requires_grad = False
         self.assertTrue(ModuleValidator.is_valid(model))

--- a/opacus/tests/multigpu_gradcheck.py
+++ b/opacus/tests/multigpu_gradcheck.py
@@ -24,6 +24,7 @@ import torch.nn as nn
 import torch.optim as optim
 from opacus import PrivacyEngine
 from opacus.distributed import DifferentiallyPrivateDistributedDataParallel as DPDDP
+from opacus.grad_sample.gsm_exp_weights import API_CUTOFF_VERSION
 from opacus.optimizers.ddp_perlayeroptimizer import (
     DistributedPerLayerOptimizer,
     SimpleDistributedPerLayerOptimizer,
@@ -147,7 +148,7 @@ class GradientComputationTest(unittest.TestCase):
             n_gpus >= 2, f"Need at least 2 gpus but was provided only {n_gpus}."
         )
 
-        if torch.__version__ < (1, 12):
+        if torch.__version__ < API_CUTOFF_VERSION:
             grad_sample_modes = ["hooks"]
         else:
             grad_sample_modes = ["hooks", "ew"]

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -27,6 +27,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from hypothesis import given, settings
 from opacus import PrivacyEngine
+from opacus.grad_sample.gsm_exp_weights import API_CUTOFF_VERSION
 from opacus.layers.dp_multihead_attention import DPMultiheadAttention
 from opacus.optimizers.optimizer import _generate_noise
 from opacus.scheduler import StepNoise
@@ -758,7 +759,9 @@ class PrivacyEngineConvNetTest(BasePrivacyEngineTest, unittest.TestCase):
         return SampleConvNet()
 
 
-@unittest.skipIf(torch.__version__ < (1, 12), "not supported in this torch version")
+@unittest.skipIf(
+    torch.__version__ < API_CUTOFF_VERSION, "not supported in this torch version"
+)
 class PrivacyEngineConvNetTestExpandedWeights(PrivacyEngineConvNetTest):
     def setUp(self):
         super().setUp()

--- a/opacus/tests/privacy_engine_validation_test.py
+++ b/opacus/tests/privacy_engine_validation_test.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from opacus import PrivacyEngine
+from opacus.grad_sample.gsm_exp_weights import API_CUTOFF_VERSION
 from torch.utils.data import DataLoader
 
 
@@ -88,6 +89,9 @@ class PrivacyEngineValidationTest(unittest.TestCase):
         for x in dl:
             module(x)
 
+    @unittest.skipIf(
+        torch.__version__ < API_CUTOFF_VERSION, "not supported in this torch version"
+    )
     def test_supported_ew(self):
         module, optim, dl = self._init(BasicSupportedModule())
 
@@ -116,6 +120,9 @@ class PrivacyEngineValidationTest(unittest.TestCase):
                 grad_sample_mode="hooks",
             )
 
+    @unittest.skipIf(
+        torch.__version__ < API_CUTOFF_VERSION, "not supported in this torch version"
+    )
     def test_custom_linear_ew(self):
         module, optim, dl = self._init(CustomLinearModule(5, 8))
 
@@ -144,6 +151,9 @@ class PrivacyEngineValidationTest(unittest.TestCase):
                 grad_sample_mode="hooks",
             )
 
+    @unittest.skipIf(
+        torch.__version__ < API_CUTOFF_VERSION, "not supported in this torch version"
+    )
     def test_unsupported_ew(self):
         module, optim, dl = self._init(MatmulModule(5, 8))
 
@@ -185,6 +195,9 @@ class PrivacyEngineValidationTest(unittest.TestCase):
         for x in dl:
             module(x)
 
+    @unittest.skipIf(
+        torch.__version__ < API_CUTOFF_VERSION, "not supported in this torch version"
+    )
     def test_extra_param_ew(self):
         module, optim, dl = self._init(LinearWithExtraParam())
         module, optim, dl = self.privacy_engine.make_private(
@@ -199,6 +212,9 @@ class PrivacyEngineValidationTest(unittest.TestCase):
             for x in dl:
                 module(x)
 
+    @unittest.skipIf(
+        torch.__version__ < API_CUTOFF_VERSION, "not supported in this torch version"
+    )
     def test_extra_param_disabled_ew(self):
         module, optim, dl = self._init(LinearWithExtraParam())
         module.extra_param.requires_grad = False

--- a/opacus/tests/privacy_engine_validation_test.py
+++ b/opacus/tests/privacy_engine_validation_test.py
@@ -1,0 +1,216 @@
+import unittest
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from opacus import PrivacyEngine
+from torch.utils.data import DataLoader
+
+
+class BasicSupportedModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv1d(in_channels=16, out_channels=8, kernel_size=2)
+        self.gn = nn.GroupNorm(num_groups=2, num_channels=8)
+        self.fc = nn.Linear(in_features=4, out_features=8)
+        self.ln = nn.LayerNorm([8, 8])
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.gn(x)
+        x = self.fc(x)
+        x = self.ln(x)
+        return x
+
+
+class CustomLinearModule(nn.Module):
+    def __init__(self, in_features, out_features):
+        super().__init__()
+        self._weight = nn.Parameter(torch.empty(out_features, in_features))
+        self._bias = nn.Parameter(torch.empty(out_features))
+
+    def forward(self, x):
+        return F.linear(x, self._weight, self._bias)
+
+
+class MatmulModule(nn.Module):
+    def __init__(self, input_features, output_features):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(input_features, output_features))
+
+    def forward(self, x):
+        return torch.matmul(x, self.weight)
+
+
+class LinearWithExtraParam(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(5, 8)
+        self.extra_param = nn.Parameter(torch.empty(8, 2))
+
+    def forward(self, x):
+        x = self.fc(x)
+        x = x.matmul(self.extra_param)
+        return x
+
+
+class PrivacyEngineValidationTest(unittest.TestCase):
+    """
+    This test case checks end-to-end model validation performed in `.make_private`
+    method. It covers performed in `ModuleValidator`, `GradSampleModule`, as well as
+    their interplay
+    """
+
+    def setUp(self) -> None:
+        self.privacy_engine = PrivacyEngine()
+
+    def _init(self, module):
+        optim = torch.optim.SGD(module.parameters(), lr=0.1)
+        dl = DataLoader(
+            dataset=[torch.randn(16, 5) for _ in range(100)],
+            batch_size=10,
+        )
+
+        return module, optim, dl
+
+    def test_supported_hooks(self):
+        module, optim, dl = self._init(BasicSupportedModule())
+
+        module, optim, dl = self.privacy_engine.make_private(
+            module=module,
+            optimizer=optim,
+            data_loader=dl,
+            noise_multiplier=1.0,
+            max_grad_norm=1.0,
+            grad_sample_mode="hooks",
+        )
+
+        for x in dl:
+            module(x)
+
+    def test_supported_ew(self):
+        module, optim, dl = self._init(BasicSupportedModule())
+
+        module, optim, dl = self.privacy_engine.make_private(
+            module=module,
+            optimizer=optim,
+            data_loader=dl,
+            noise_multiplier=1.0,
+            max_grad_norm=1.0,
+            grad_sample_mode="ew",
+        )
+
+        for x in dl:
+            module(x)
+
+    def test_custom_linear_hooks(self):
+        module, optim, dl = self._init(CustomLinearModule(5, 8))
+
+        with self.assertRaises(NotImplementedError):
+            self.privacy_engine.make_private(
+                module=module,
+                optimizer=optim,
+                data_loader=dl,
+                noise_multiplier=1.0,
+                max_grad_norm=1.0,
+                grad_sample_mode="hooks",
+            )
+
+    def test_custom_linear_ew(self):
+        module, optim, dl = self._init(CustomLinearModule(5, 8))
+
+        module, optim, dl = self.privacy_engine.make_private(
+            module=module,
+            optimizer=optim,
+            data_loader=dl,
+            noise_multiplier=1.0,
+            max_grad_norm=1.0,
+            grad_sample_mode="ew",
+        )
+
+        for x in dl:
+            module(x)
+
+    def test_unsupported_hooks(self):
+        module, optim, dl = self._init(MatmulModule(5, 8))
+
+        with self.assertRaises(NotImplementedError):
+            self.privacy_engine.make_private(
+                module=module,
+                optimizer=optim,
+                data_loader=dl,
+                noise_multiplier=1.0,
+                max_grad_norm=1.0,
+                grad_sample_mode="hooks",
+            )
+
+    def test_unsupported_ew(self):
+        module, optim, dl = self._init(MatmulModule(5, 8))
+
+        module, optim, dl = self.privacy_engine.make_private(
+            module=module,
+            optimizer=optim,
+            data_loader=dl,
+            noise_multiplier=1.0,
+            max_grad_norm=1.0,
+            grad_sample_mode="ew",
+        )
+
+        with self.assertRaises(RuntimeError):
+            for x in dl:
+                module(x)
+
+    def test_extra_param_hooks(self):
+        module, optim, dl = self._init(LinearWithExtraParam())
+        with self.assertRaises(NotImplementedError):
+            self.privacy_engine.make_private(
+                module=module,
+                optimizer=optim,
+                data_loader=dl,
+                noise_multiplier=1.0,
+                max_grad_norm=1.0,
+                grad_sample_mode="hooks",
+            )
+
+        module.extra_param.requires_grad = False
+        module, optim, dl = self.privacy_engine.make_private(
+            module=module,
+            optimizer=optim,
+            data_loader=dl,
+            noise_multiplier=1.0,
+            max_grad_norm=1.0,
+            grad_sample_mode="hooks",
+        )
+
+        for x in dl:
+            module(x)
+
+    def test_extra_param_ew(self):
+        module, optim, dl = self._init(LinearWithExtraParam())
+        module, optim, dl = self.privacy_engine.make_private(
+            module=module,
+            optimizer=optim,
+            data_loader=dl,
+            noise_multiplier=1.0,
+            max_grad_norm=1.0,
+            grad_sample_mode="ew",
+        )
+        with self.assertRaises(RuntimeError):
+            for x in dl:
+                module(x)
+
+    def test_extra_param_disabled_ew(self):
+        module, optim, dl = self._init(LinearWithExtraParam())
+        module.extra_param.requires_grad = False
+
+        module, optim, dl = self.privacy_engine.make_private(
+            module=module,
+            optimizer=optim,
+            data_loader=dl,
+            noise_multiplier=1.0,
+            max_grad_norm=1.0,
+            grad_sample_mode="ew",
+        )
+
+        for x in dl:
+            module(x)

--- a/opacus/validators/module_validator.py
+++ b/opacus/validators/module_validator.py
@@ -17,7 +17,6 @@ import logging
 from typing import List
 
 import torch.nn as nn
-from opacus.grad_sample.grad_sample_module import GradSampleModule
 from opacus.utils.module_utils import clone_module, get_submodule, trainable_modules
 from opacus.validators.errors import (
     IllegalModuleConfigurationError,
@@ -59,9 +58,7 @@ class ModuleValidator:
             errors.append(
                 IllegalModuleConfigurationError("Model needs to be in training mode")
             )
-        # 2. validate that all trainable modules are supported by GradSampleModule.
-        errors.extend(GradSampleModule.validate(module=module, strict=False))
-        # 3. perform module specific validations for trainable modules.
+        # 2. perform module specific validations for trainable modules.
         # TODO: use module name here - it's useful part of error message
         for _, sub_module in trainable_modules(module):
             if type(sub_module) in ModuleValidator.VALIDATORS:


### PR DESCRIPTION
This PR brings few assorted updates related to the new ExpandedWeights API

## Validation
Previously, `ModelValidator` was the one-stop shop for checking the input model: it checked whether we support it (via a call to `GradSampleModule.validate`) and whether the module is DP-valid.

Now with multiple implementations of `GradSampleModule` with varying module support criteria, I propose to separate the responsibilities in the following way:
- `ModuleValidator` is responsible for checking **known** DP violations
- `GradSampleModule` is responsible for checking if it's able to handle given input module. It'll do so to the best of it's abilities: hook-based GSM will perform check in the constructor, while ExpandedWeights-based GSM will do so dynamically during the forward call
- To reflect changes above, we'd need to introduce new tests. I suggest we keep most of the `ModuleValidator` tests + introduce a new one to check the output on a level of `PrivacyEngine.make_private()`

See also discussion in #454 for more context

## Enable some `ExpandedWeights` tests back
We've acknowledged some limitations of `ExpandedWeights` by disabling certain tests. With significant progress being made ([loss reduction fix](https://github.com/pytorch/pytorch/pull/80892), [conv3d fix](https://github.com/pytorch/pytorch/pull/80943), [LayerNorm fix](https://github.com/pytorch/pytorch/pull/80895), [InstanceNorm fix](https://github.com/pytorch/pytorch/pull/79800)) we can enable some of them back. I've also removed some obsolete entries from the Readme

## Scrape EW compatibility API
The initial idea was to temporarily provide support for both iterations of ExpandedWeights: old API in PyTorch 1.12 and new API in 1.13. However, with a significant amount of bugfixes (see paragraph above), it's no longer practical to keep supporting 1.12 - that's a lot of convoluted code for a scant amount of benefits. With that, I've removed all of the compatibility API bits and only allow `ExpandedWeights` usage with the 1.13+