### PR TITLE
reduce logging severity for set_to_none

### DIFF
--- a/opacus/grad_sample/gsm_base.py
+++ b/opacus/grad_sample/gsm_base.py
@@ -94,7 +94,7 @@ class AbstractGradSampleModule(nn.Module, ABC):
             affects regular gradients. Per sample gradients are always set to None)
         """
         if set_to_none is False:
-            logger.info(
+            logger.debug(
                 "Despite set_to_none is set to False, "
                 "opacus will set p.grad_sample to None due to "
                 "non-trivial gradient accumulation behaviour"

--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -462,7 +462,7 @@ class DPOptimizer(Optimizer):
         """
 
         if set_to_none is False:
-            logger.info(
+            logger.debug(
                 "Despite set_to_none is set to False, "
                 "opacus will set p.grad_sample and p.summed_grad to None due to "
                 "non-trivial gradient accumulation behaviour"


### PR DESCRIPTION
We want to warn users of an unexpected behaviour with `set_to_none` flag. Normally, both `nn.Module` and `Optimizer` let clients choose whether they want to remove the `.grad` attribute altogether or just set it to None.
We, on the other hand, don't want to remove the attributes - it's more convenient to assume the `.grad_sample` attribute is always present. It's not an absolute requirement, but we did that historically and I don't see a case for changing it now.

However, default value for `set_to_none` is False, meaning most users are getting annoying logging notifications on every training step.
