### PR TITLE
explicit opt_einsum.contract import

### DIFF
--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -19,7 +19,7 @@ from typing import Callable, List, Optional, Union
 
 import torch
 from opacus.optimizers.utils import params
-from opt_einsum import contract
+from opt_einsum.contract import contract
 from torch import nn
 from torch.optim import Optimizer
 


### PR DESCRIPTION
`opt_einsum` package contains ambiguous imports. It has submodule `opt_einsum/contract.py` and at the same time has the following in `__init__.py`:
```
from .contract import contract
``` 

So normally `from opt_einsum import contract` should import the method not the module. Howeve, some build systems are not very smart (looking at you buck) and get confused.

This change removes ambiguity and shouldn't affect behaviour in any way