### PR TITLE
Add benchmarks to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,35 @@ commands:
       - store_artifacts:
           path: runs/charlstm/test-reports
 
+  benchmark_layers_integration_test:
+    description: "Runs benchmark end to end"
+    parameters:
+      device:
+        default: "cpu"
+        type: string
+      layers:
+        default: "mha dpmha gsm_dpmha embedding gsm_embedding instancenorm gsm_instancenorm groupnorm gsm_groupnorm layernorm gsm_layernorm lstm dplstm gsm_dplstm rnn dprnn gsm_dprnn linear gsm_linear gru dpgru gsm_dpgru"
+        type: string
+      runtime_ratio_threshold:
+        default: "7.0"
+        type: string
+      memory_ratio_threshold:
+        default: "2.0"
+        type: string
+    steps:
+      - run:
+          name: benchmarks
+          command: |
+            mkdir -p benchmarks/results/raw
+            echo "Using $(python -V) ($(which python))"
+            echo "Using $(pip -V) ($(which pip))"
+            python benchmarks/run_benchmarks.py --batch_size 16 --layers <<parameters.layers>> --config_file ./benchmarks/config.json --root ./benchmarks/results/raw/ --cont
+            layers<<parameters.layers>>; layers_list=(${(@s: :)layers}); mkdir /tmp/report_layers; cp -v ${:-${^layers_list}*} /tmp/report_layers
+            python benchmarks/generate_report.py --path-to-results /tmp/report_layers --save-path benchmarks/results/report.csv
+            python -c "import pandas as pd; r = pd.read_csv('.benchmarks/results/report.csv').fillna(0); th="<<parameters.runtime_ratio_threshold>>"; exit(0) if (r.loc[:, ('runtime', 'dp/control')] < th).all() and (r.loc[:, ('runtime', 'gsm/control')] < th).all() else exit(1)"
+          when: always
+      - store_artifacts:
+          path: benchmarks/results/
 # -------------------------------------------------------------------------------------
 # Jobs
 # -------------------------------------------------------------------------------------
@@ -315,6 +344,26 @@ jobs:
           device: "cuda"
       - dcgan_integration_test:
           device: "cuda"
+      - benchmark_layers_integration_test:
+          device: "cuda"
+          layers: "groupnorm gsm_groupnorm gru dp_gru instancenorm gsm_instancenorm layernorm gsm_layernorm lstm dplstm mha dpmha gsm_dpmha rnn dprnn"
+          runtime_ratio_threshold: "2.5"
+          memory_ratio_threshold: "1.6"
+      - benchmark_layers_integration_test:
+          device: "cuda"
+          layers: linear gsm_linear
+          runtime_ratio_threshold: "3.3"
+          memory_ratio_threshold: "13.0"
+      - benchmark_layers_integration_test:
+          device: "cuda"
+          layers: "gru gsm_dpgru lstm gsm_dplstm rnn gsm_dprnn"
+          runtime_ratio_threshold: "7.0"
+          memory_ratio_threshold: "1.5"
+      - benchmark_layers_integration_test:
+          device: "cuda"
+          layers: "embedding gsm_embedding"
+          runtime_ratio_threshold: "6.0"
+          memory_ratio_threshold: "15.0"
 
   unittest_multi_gpu:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ commands:
             echo "Using $(python -V) ($(which python))"
             echo "Using $(pip -V) ($(which pip))"
             python benchmarks/run_benchmarks.py --batch_size 16 --layers <<parameters.layers>> --config_file ./benchmarks/config.json --root ./benchmarks/results/raw/ --cont
-            IFS=$' ';layers=(<<parameters.layers>>); mkdir /tmp/report_layers; IFS=$'\n'; files=`( echo "${layers[*]}" ) | sed 's/.*/.\/benchmarks\/results\/raw\/&*/'`
+            IFS=$' ';layers=(<<parameters.layers>>); mkdir -p /tmp/report_layers; IFS=$'\n'; files=`( echo "${layers[*]}" ) | sed 's/.*/.\/benchmarks\/results\/raw\/&*/'`
             cp -v ${files[@]} /tmp/report_layers
             report_id=`IFS=$'-'; echo "${layers[*]}"`
             python benchmarks/generate_report.py --path-to-results /tmp/report_layers --save-path benchmarks/results/report-${report_id}.csv --format csv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,26 @@ jobs:
       - py_3_7_setup
       - pip_dev_install
       - run_nvidia_smi
+      - mnist_integration_test:
+          device: "cuda"
+      - cifar10_integration_test:
+          device: "cuda"
+      - imdb_integration_test:
+          device: "cuda"
+      - charlstm_integration_test:
+          device: "cuda"
+      - dcgan_integration_test:
+          device: "cuda"
+
+  micro_benchmarks_py37_torch_release_cuda:
+    machine:
+      resource_class: gpu.nvidia.small.multi
+      image: ubuntu-2004-cuda-11.4:202110-01
+    steps:
+      - checkout
+      - py_3_7_setup
+      - pip_dev_install
+      - run_nvidia_smi
       - benchmark_layers_integration_test:
           device: "cuda"
           layers: "groupnorm gsm_groupnorm instancenorm gsm_instancenorm layernorm gsm_layernorm mha dpmha"
@@ -356,34 +376,39 @@ jobs:
           memory_ratio_threshold: "2.0"
       - benchmark_layers_integration_test:
           device: "cuda"
-          layers: "gru dpgru gsm_dpgru"
+          layers: "gru dpgru"
           runtime_ratio_threshold: "18.5"
-          memory_ratio_threshold: "1.5"
+          memory_ratio_threshold: "1.2"
       - benchmark_layers_integration_test:
           device: "cuda"
-          layers: "lstm dplstm gsm_dplstm"
-          runtime_ratio_threshold: "16.5"
-          memory_ratio_threshold: "1.5"
+          layers: "gru gsm_dpgru"
+          runtime_ratio_threshold: "40"
+          memory_ratio_threshold: "1.6"
       - benchmark_layers_integration_test:
           device: "cuda"
-          layers: "rnn dprnn gsm_dprnn"
+          layers: "lstm dplstm"
           runtime_ratio_threshold: "16.5"
           memory_ratio_threshold: "1.2"
       - benchmark_layers_integration_test:
           device: "cuda"
+          layers: "lstm gsm_dplstm"
+          runtime_ratio_threshold: "38.0"
+          memory_ratio_threshold: "1.8"
+      - benchmark_layers_integration_test:
+          device: "cuda"
+          layers: "rnn dprnn"
+          runtime_ratio_threshold: "10.0"
+          memory_ratio_threshold: "1.2"
+      - benchmark_layers_integration_test:
+          device: "cuda"
+          layers: "rnn gsm_dprnn"
+          runtime_ratio_threshold: "33.0"
+          memory_ratio_threshold: "1.2"
+      - benchmark_layers_integration_test:
+          device: "cuda"
           layers: "embedding gsm_embedding"
-          runtime_ratio_threshold: "6.0"
+          runtime_ratio_threshold: "8.0"
           memory_ratio_threshold: "15.0"
-      - mnist_integration_test:
-          device: "cuda"
-      - cifar10_integration_test:
-          device: "cuda"
-      - imdb_integration_test:
-          device: "cuda"
-      - charlstm_integration_test:
-          device: "cuda"
-      - dcgan_integration_test:
-          device: "cuda"
 
   unittest_multi_gpu:
     machine:
@@ -448,6 +473,8 @@ workflows:
           filters: *exclude_ghpages
       - integrationtest_py37_torch_release_cuda:
           filters: *exclude_ghpages
+      - micro_benchmarks_py37_torch_release_cuda:
+          filters: *exclude_ghpages
 
   nightly:
     when:
@@ -460,6 +487,8 @@ workflows:
       - integrationtest_py37_torch_release_cuda:
           filters: *exclude_ghpages
       - lint_py37_torch_release:
+          filters: *exclude_ghpages
+      - micro_benchmarks_py37_torch_release_cuda:
           filters: *exclude_ghpages
 
   website_deployment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
       - run_nvidia_smi
       - benchmark_layers_integration_test:
           device: "cuda"
-          layers: "groupnorm gsm_groupnorm gru dpgru instancenorm gsm_instancenorm layernorm gsm_layernorm lstm dplstm mha dpmha gsm_dpmha rnn dprnn"
+          layers: "groupnorm gsm_groupnorm instancenorm gsm_instancenorm layernorm gsm_layernorm"
           runtime_ratio_threshold: "2.5"
           memory_ratio_threshold: "1.6"
       - benchmark_layers_integration_test:
@@ -351,9 +351,24 @@ jobs:
           memory_ratio_threshold: "13.0"
       - benchmark_layers_integration_test:
           device: "cuda"
-          layers: "gru gsm_dpgru lstm gsm_dplstm rnn gsm_dprnn"
-          runtime_ratio_threshold: "7.0"
+          layers: "mha gsm_dpmha"
+          runtime_ratio_threshold: "3.5"
+          memory_ratio_threshold: "2.0"
+      - benchmark_layers_integration_test:
+          device: "cuda"
+          layers: "gru dpgru gsm_dpgru"
+          runtime_ratio_threshold: "18.5"
           memory_ratio_threshold: "1.5"
+      - benchmark_layers_integration_test:
+          device: "cuda"
+          layers: "lstm dplstm gsm_dplstm"
+          runtime_ratio_threshold: "16.5"
+          memory_ratio_threshold: "1.5"
+      - benchmark_layers_integration_test:
+          device: "cuda"
+          layers: "rnn dprnn gsm_dprnn"
+          runtime_ratio_threshold: "16.5"
+          memory_ratio_threshold: "1.2"
       - benchmark_layers_integration_test:
           device: "cuda"
           layers: "embedding gsm_embedding"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ commands:
             echo "Using $(python -V) ($(which python))"
             echo "Using $(pip -V) ($(which pip))"
             python benchmarks/run_benchmarks.py --batch_size 16 --layers <<parameters.layers>> --config_file ./benchmarks/config.json --root ./benchmarks/results/raw/ --cont
-            IFS=$' ';layers=(<<parameters.layers>>); mkdir -p /tmp/report_layers; IFS=$'\n'; files=`( echo "${layers[*]}" ) | sed 's/.*/.\/benchmarks\/results\/raw\/&*/'`
+            IFS=$' ';layers=(<<parameters.layers>>); rm -rf /tmp/report_layers; mkdir -p /tmp/report_layers; IFS=$'\n'; files=`( echo "${layers[*]}" ) | sed 's/.*/.\/benchmarks\/results\/raw\/&*/'`
             cp -v ${files[@]} /tmp/report_layers
             report_id=`IFS=$'-'; echo "${layers[*]}"`
             python benchmarks/generate_report.py --path-to-results /tmp/report_layers --save-path benchmarks/results/report-${report_id}.csv --format csv
@@ -339,16 +339,6 @@ jobs:
       - py_3_7_setup
       - pip_dev_install
       - run_nvidia_smi
-      - mnist_integration_test:
-          device: "cuda"
-      - cifar10_integration_test:
-          device: "cuda"
-      - imdb_integration_test:
-          device: "cuda"
-      - charlstm_integration_test:
-          device: "cuda"
-      - dcgan_integration_test:
-          device: "cuda"
       - benchmark_layers_integration_test:
           device: "cuda"
           layers: "groupnorm gsm_groupnorm gru dpgru instancenorm gsm_instancenorm layernorm gsm_layernorm lstm dplstm mha dpmha gsm_dpmha rnn dprnn"
@@ -369,6 +359,16 @@ jobs:
           layers: "embedding gsm_embedding"
           runtime_ratio_threshold: "6.0"
           memory_ratio_threshold: "15.0"
+      - mnist_integration_test:
+          device: "cuda"
+      - cifar10_integration_test:
+          device: "cuda"
+      - imdb_integration_test:
+          device: "cuda"
+      - charlstm_integration_test:
+          device: "cuda"
+      - dcgan_integration_test:
+          device: "cuda"
 
   unittest_multi_gpu:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,11 +261,13 @@ commands:
             echo "Using $(python -V) ($(which python))"
             echo "Using $(pip -V) ($(which pip))"
             python benchmarks/run_benchmarks.py --batch_size 16 --layers <<parameters.layers>> --config_file ./benchmarks/config.json --root ./benchmarks/results/raw/ --cont
-            layers=(<<parameters.layers>>); mkdir /tmp/report_layers; files=`( IFS=$'\n'; echo "${layers[*]}" ) | sed 's/.*/.\/benchmarks\/results\/raw\/&*/'`
+            IFS=$' ';layers=(<<parameters.layers>>); mkdir /tmp/report_layers; IFS=$'\n'; files=`( echo "${layers[*]}" ) | sed 's/.*/.\/benchmarks\/results\/raw\/&*/'`
             cp -v ${files[@]} /tmp/report_layers
-            python benchmarks/generate_report.py --path-to-results /tmp/report_layers --save-path benchmarks/results/report.csv --format csv
-            python benchmarks/generate_report.py --path-to-results /tmp/report_layers --save-path benchmarks/results/report.pkl --format pkl
-            python -c "import pandas as pd; r = pd.read_pickle('./benchmarks/results/report.pkl').fillna(0); th="<<parameters.runtime_ratio_threshold>>"; exit(0) if (r.loc[:, ('runtime', 'dp/control')] < th).all() and (r.loc[:, ('runtime', 'gsm/control')] < th).all() else exit(1)"
+            report_id=`IFS=$'-'; echo "${layers[*]}"`
+            python benchmarks/generate_report.py --path-to-results /tmp/report_layers --save-path benchmarks/results/report-${report_id}.csv --format csv
+            python benchmarks/generate_report.py --path-to-results /tmp/report_layers --save-path benchmarks/results/report-${report_id}.pkl --format pkl
+            python -c "import pandas as pd; r = pd.read_pickle('./benchmarks/results/report-"$report_id".pkl').fillna(0); th="<<parameters.runtime_ratio_threshold>>"; exit(0) if (r.loc[:, ('runtime', 'dp/control')] < th).all() and (r.loc[:, ('runtime', 'gsm/control')] < th).all() else exit(1)"
+            python -c "import pandas as pd; r = pd.read_pickle('./benchmarks/results/report-"$report_id".pkl').fillna(0); th="<<parameters.memory_ratio_threshold>>"; exit(0) if (r.loc[:, ('memory', 'dp/control')] < th).all() and (r.loc[:, ('memory', 'gsm/control')] < th).all() else exit(1)"
           when: always
       - store_artifacts:
           path: benchmarks/results/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,8 +473,6 @@ workflows:
           filters: *exclude_ghpages
       - integrationtest_py37_torch_release_cuda:
           filters: *exclude_ghpages
-      - micro_benchmarks_py37_torch_release_cuda:
-          filters: *exclude_ghpages
 
   nightly:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,12 +341,12 @@ jobs:
       - run_nvidia_smi
       - benchmark_layers_integration_test:
           device: "cuda"
-          layers: "groupnorm gsm_groupnorm instancenorm gsm_instancenorm layernorm gsm_layernorm"
-          runtime_ratio_threshold: "2.5"
+          layers: "groupnorm gsm_groupnorm instancenorm gsm_instancenorm layernorm gsm_layernorm mha dpmha"
+          runtime_ratio_threshold: "2.6"
           memory_ratio_threshold: "1.6"
       - benchmark_layers_integration_test:
           device: "cuda"
-          layers: linear gsm_linear
+          layers: "linear gsm_linear"
           runtime_ratio_threshold: "3.6"
           memory_ratio_threshold: "13.0"
       - benchmark_layers_integration_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,9 +261,11 @@ commands:
             echo "Using $(python -V) ($(which python))"
             echo "Using $(pip -V) ($(which pip))"
             python benchmarks/run_benchmarks.py --batch_size 16 --layers <<parameters.layers>> --config_file ./benchmarks/config.json --root ./benchmarks/results/raw/ --cont
-            layers<<parameters.layers>>; layers_list=(${(@s: :)layers}); mkdir /tmp/report_layers; cp -v ${:-${^layers_list}*} /tmp/report_layers
-            python benchmarks/generate_report.py --path-to-results /tmp/report_layers --save-path benchmarks/results/report.csv
-            python -c "import pandas as pd; r = pd.read_csv('.benchmarks/results/report.csv').fillna(0); th="<<parameters.runtime_ratio_threshold>>"; exit(0) if (r.loc[:, ('runtime', 'dp/control')] < th).all() and (r.loc[:, ('runtime', 'gsm/control')] < th).all() else exit(1)"
+            layers=(<<parameters.layers>>); mkdir /tmp/report_layers; files=`( IFS=$'\n'; echo "${layers[*]}" ) | sed 's/.*/.\/benchmarks\/results\/raw\/&*/'`
+            cp -v ${files[@]} /tmp/report_layers
+            python benchmarks/generate_report.py --path-to-results /tmp/report_layers --save-path benchmarks/results/report.csv --format csv
+            python benchmarks/generate_report.py --path-to-results /tmp/report_layers --save-path benchmarks/results/report.pkl --format pkl
+            python -c "import pandas as pd; r = pd.read_pickle('./benchmarks/results/report.pkl').fillna(0); th="<<parameters.runtime_ratio_threshold>>"; exit(0) if (r.loc[:, ('runtime', 'dp/control')] < th).all() and (r.loc[:, ('runtime', 'gsm/control')] < th).all() else exit(1)"
           when: always
       - store_artifacts:
           path: benchmarks/results/
@@ -321,6 +323,7 @@ jobs:
       - image: cimg/python:3.7.5
     steps:
       - checkout
+      - py_3_7_setup
       - pip_dev_install
       - mnist_integration_test:
           device: "cpu"
@@ -346,13 +349,13 @@ jobs:
           device: "cuda"
       - benchmark_layers_integration_test:
           device: "cuda"
-          layers: "groupnorm gsm_groupnorm gru dp_gru instancenorm gsm_instancenorm layernorm gsm_layernorm lstm dplstm mha dpmha gsm_dpmha rnn dprnn"
+          layers: "groupnorm gsm_groupnorm gru dpgru instancenorm gsm_instancenorm layernorm gsm_layernorm lstm dplstm mha dpmha gsm_dpmha rnn dprnn"
           runtime_ratio_threshold: "2.5"
           memory_ratio_threshold: "1.6"
       - benchmark_layers_integration_test:
           device: "cuda"
           layers: linear gsm_linear
-          runtime_ratio_threshold: "3.3"
+          runtime_ratio_threshold: "3.6"
           memory_ratio_threshold: "13.0"
       - benchmark_layers_integration_test:
           device: "cuda"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -33,7 +33,7 @@ Do this num_runs times:
         loss.backward()
 
     Stop timer
-    
+
     Return elapsed time / num_repeats and memory statistics
 ```
 
@@ -107,6 +107,19 @@ optional arguments:
   -v, --verbose
 ```
 
+`generate_report.py` will take as an input the path where `run_benchmarks.py` has written the results and it will generate an CSV report.
+```
+usage: generate_report.py [-h] [--path-to-results PATH_TO_RESULTS]
+                          [--save-path SAVE_PATH]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --path-to-results PATH_TO_RESULTS
+                        the path that `run_benchmarks.py` has saved results
+                        to.
+  --save-path SAVE_PATH
+                        path to save the CSV output.
+```
 ## Tests
 
 ```python -m pytest tests/```

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -107,10 +107,10 @@ optional arguments:
   -v, --verbose
 ```
 
-`generate_report.py` will take as an input the path where `run_benchmarks.py` has written the results and it will generate an CSV report.
+`generate_report.py` will take as an input the path where `run_benchmarks.py` has written the results and it will generate a report.
 ```
 usage: generate_report.py [-h] [--path-to-results PATH_TO_RESULTS]
-                          [--save-path SAVE_PATH]
+                          [--save-path SAVE_PATH] [--format {csv,pkl}]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -118,7 +118,8 @@ optional arguments:
                         the path that `run_benchmarks.py` has saved results
                         to.
   --save-path SAVE_PATH
-                        path to save the CSV output.
+                        path to save the output.
+  --format {csv,pkl}    output format
 ```
 ## Tests
 

--- a/benchmarks/benchmark_layer.py
+++ b/benchmarks/benchmark_layer.py
@@ -62,15 +62,12 @@ def run_layer_benchmark(
     )
 
     # benchmark.Timer performs its own warmups
-    try:
-        timer = benchmark.Timer(
-            stmt="benchmark_fun()",
-            globals={"benchmark_fun": benchmark_fun},
-            num_threads=1,
-        )
-        runtime = timer.timeit(num_repeats).mean
-    except RuntimeError:
-        runtime = float("nan")
+    timer = benchmark.Timer(
+        stmt="benchmark_fun()",
+        globals={"benchmark_fun": benchmark_fun},
+        num_threads=1,
+    )
+    runtime = timer.timeit(num_repeats).mean
 
     # get max memory allocated and reset memory statistics
     memory_stats["max_memory"] = reset_peak_memory_stats(device).prev_max_mem

--- a/benchmarks/generate_report.py
+++ b/benchmarks/generate_report.py
@@ -14,8 +14,8 @@
 
 import argparse
 
-
 from utils import generate_report
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/benchmarks/generate_report.py
+++ b/benchmarks/generate_report.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+
+from utils import generate_report
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--path-to-results",
+        default="./results/raw",
+        type=str,
+        help="the path that `run_benchmarks.py` has saved results to.",
+    )
+    parser.add_argument(
+        "--save-path",
+        default="./results/report.csv",
+        type=str,
+        help="path to save the CSV output.",
+    )
+    args = parser.parse_args()
+
+    generate_report(args.path_to_results, args.save_path)

--- a/benchmarks/generate_report.py
+++ b/benchmarks/generate_report.py
@@ -29,8 +29,16 @@ if __name__ == "__main__":
         "--save-path",
         default="./results/report.csv",
         type=str,
-        help="path to save the CSV output.",
+        help="path to save the output.",
+    )
+
+    parser.add_argument(
+        "--format",
+        default="csv",
+        type=str,
+        help="output format",
+        choices=["csv", "pkl"],
     )
     args = parser.parse_args()
 
-    generate_report(args.path_to_results, args.save_path)
+    generate_report(args.path_to_results, args.save_path, args.format)

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -12,154 +12,110 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pickle
-from collections import namedtuple
-from typing import Any, Dict, List, Optional
+import argparse
+import json
+from typing import Callable, Dict, Tuple
 
 import torch
-from layers import LayerType
+import torch.utils.benchmark as benchmark
+from layers import LayerFactory, LayerType
+from utils import get_layer_set, reset_peak_memory_stats
 
 
-Memory = namedtuple("Memory", "prev_max_mem, cur_mem")
-
-
-def reset_peak_memory_stats(device: torch.device) -> Memory:
-    """Safely resets CUDA peak memory statistics of device if it is
-    a CUDA device.
-
-    Notes: ``torch.cuda.reset_peak_memory_stats(device)`` will error
-    if no CUDA memory has been allocated to the device.
-
-    Args:
-        device: A torch.device
-
-    Returns:
-        max_memory_allocated before resetting the statistics and
-        memory_allocated, both in bytes
-    """
-    prev_max_memory = torch.cuda.max_memory_allocated(device)
-    memory_allocated = torch.cuda.memory_allocated(device)
-
-    if prev_max_memory != memory_allocated and prev_max_memory > 0:
-        # raises RuntimeError if no previous allocation occurred
-        torch.cuda.reset_peak_memory_stats(device)
-        assert torch.cuda.max_memory_allocated(device) == memory_allocated
-
-    return Memory(prev_max_memory, memory_allocated)
-
-
-def get_layer_set(layer: str) -> str:
-    """Layers in the same layer set share a config.
-
-    Args:
-        layer: Full name of the layer. This will be the PyTorch or Opacus
-        name of the layer in lower case (e.g. linear, rnn, dprnn), prefixed with
-        gsm_ (e.g. gsm_linear, gsm_dprnn) if DP is enabled. MultiheadAttention
-        is abbreviated to mha.
-
-    Returns:
-        The name of the layer set, where a set of layers are defined as layers
-        that share the same __init__ signature.
-
-    Notes:
-        All RNN-based models share a config.
-
-    """
-    layer_set = layer.replace("gsm_dp", "").replace("gsm_", "").replace("dp", "")
-
-    # all RNN-based model use the same config
-    if layer_set in ["rnn", "gru", "lstm"]:
-        layer_set = "rnn_base"
-
-    return layer_set
-
-
-def get_path(
-    layer: LayerType,
-    batch_size: int,
-    num_runs: int,
+def run_layer_benchmark(
     num_repeats: int,
-    random_seed: Optional[int] = None,
     forward_only: bool = False,
-    root: str = "./results/raw/",
-    suffix: str = "",
-) -> str:
-    """Gets the path to the file where the corresponding results are located.
-    File is presumed to be a pickle file.
+    create_layer: Callable = LayerFactory.create,
+    **kwargs,
+) -> Tuple[float, Dict[str, int]]:
+    """Benchmarks a single layer for runtime and CUDA memory (if applicable).
 
     Args:
-        layer: full layer name
-        batch_size: batch size
-        num_runs: number of runs per benchmark
-        num_repeats: how many benchmarks were run
-        random_seed: the initial random seed
-        forward_only: whether backward passes were skipped
-        root: directory to write results to
-        suffix: optional string to append to file name
+        num_repeats: how many times to repeat the forward(/backward) pass
+        forward_only: whether to skip the backward pass
+        create_layer: function for creating the layer, takes **kwargs
 
-    Returns:
-        Path to results pickle file
+    Returns: a tuple consisting of
+        Runtime as a float, and
+        Memory statistics as a dict
     """
-    pickle_name = f"{layer}_bs_{batch_size}_runs_{num_runs}_repeats_{num_repeats}_seed_{random_seed}"
+
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+    if torch.cuda.is_available():
+        assert reset_peak_memory_stats(device).cur_mem == 0
+
+    # setup layer
+    layer_fun = create_layer(**kwargs)
+
     if forward_only:
-        pickle_name += "_forward_only"
+        layer_fun.module.eval()
+        benchmark_fun = layer_fun.forward_only
+    else:
+        layer_fun.module.train()
+        benchmark_fun = layer_fun.forward_backward
 
-    if len(suffix) and not suffix.startswith("_"):
-        suffix = f"_{suffix}"
-
-    return f"{root}{pickle_name}{suffix}.pkl"
-
-
-def save_results(
-    layer: LayerType,
-    batch_size: int,
-    num_runs: int,
-    num_repeats: int,
-    results: List[Dict[str, Any]],
-    config: Dict[str, Any],
-    random_seed: Optional[int] = None,
-    forward_only: bool = False,
-    root: str = "./results/raw/",
-    suffix: str = "",
-) -> None:
-    """Saves the corresponding results as a pickle file.
-
-    Args:
-        layer: full layer name
-        batch_size: batch size
-        num_runs: number of runs per benchmark
-        num_repeats: how many benchmarks were run
-        runtimes: list of runtimes of length num_repeats
-        memory: list of memory stats of length num_repeats
-        config: layer config
-        random_seed: the initial random seed
-        forward_only: whether backward passes were skipped
-        root: directory to write results to
-        suffix: optional string to append to file name
-    """
-    path = get_path(
-        layer=layer,
-        batch_size=batch_size,
-        num_runs=num_runs,
-        num_repeats=num_repeats,
-        random_seed=random_seed,
-        forward_only=forward_only,
-        root=root,
-        suffix=suffix,
+    # move layer to device and get memory statistics
+    memory_stats = layer_fun.to(device=device)
+    assert sum(v for _, v in memory_stats.items()) == torch.cuda.memory_allocated(
+        device
     )
 
-    with open(path, "wb") as handle:
-        pickle.dump(
-            {
-                "layer": layer,
-                "batch_size": batch_size,
-                "num_runs": num_runs,
-                "num_repeats": num_repeats,
-                "random_seed": random_seed,
-                "forward_only": forward_only,
-                "results": results,
-                "config": config,
-            },
-            handle,
-            protocol=pickle.HIGHEST_PROTOCOL,
-        )
+    # benchmark.Timer performs its own warmups
+    timer = benchmark.Timer(
+        stmt="benchmark_fun()",
+        globals={"benchmark_fun": benchmark_fun},
+        num_threads=1,
+    )
+    runtime = timer.timeit(num_repeats).mean
+
+    # get max memory allocated and reset memory statistics
+    memory_stats["max_memory"] = reset_peak_memory_stats(device).prev_max_mem
+
+    return runtime, memory_stats
+
+
+def main(args) -> None:
+
+    with open(args.config_file) as config_file:
+        config = json.load(config_file)
+
+    runtime, memory_stats = run_layer_benchmark(
+        num_repeats=args.num_repeats,
+        forward_only=args.forward_only,
+        layer_name=args.layer,
+        batch_size=args.batch_size,
+        random_seed=args.random_seed,
+        **config[get_layer_set(args.layer)],
+    )
+    print(f"Runtime (seconds): {runtime}")
+    print(f"Memory statistics (bytes): {memory_stats}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "layer",
+        type=str,
+        choices=[v for k, v in LayerType.__dict__.items() if not k.startswith("__")],
+    )
+    parser.add_argument("--batch_size", default=64, type=int)
+    parser.add_argument(
+        "--num_repeats",
+        default=20,
+        type=int,
+        help="number of forward/backward passes to run",
+    )
+    parser.add_argument(
+        "--forward_only", action="store_true", help="only run forward passes"
+    )
+    parser.add_argument("--random_seed", default=0, type=int)
+    parser.add_argument(
+        "-c",
+        "--config_file",
+        default="config.json",
+        type=str,
+        help="path to config file with settings for each layer",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -12,110 +12,231 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
-import json
-from typing import Callable, Dict, Tuple
+import pickle
+import glob
+from collections import namedtuple
+from typing import Any, Dict, List, Optional
 
 import torch
-import torch.utils.benchmark as benchmark
-from layers import LayerFactory, LayerType
-from utils import get_layer_set, reset_peak_memory_stats
+from layers import LayerType
+import numpy as np
+import pandas as pd
+
+Memory = namedtuple("Memory", "prev_max_mem, cur_mem")
 
 
-def run_layer_benchmark(
-    num_repeats: int,
-    forward_only: bool = False,
-    create_layer: Callable = LayerFactory.create,
-    **kwargs,
-) -> Tuple[float, Dict[str, int]]:
-    """Benchmarks a single layer for runtime and CUDA memory (if applicable).
+def reset_peak_memory_stats(device: torch.device) -> Memory:
+    """Safely resets CUDA peak memory statistics of device if it is
+    a CUDA device.
+
+    Notes: ``torch.cuda.reset_peak_memory_stats(device)`` will error
+    if no CUDA memory has been allocated to the device.
 
     Args:
-        num_repeats: how many times to repeat the forward(/backward) pass
-        forward_only: whether to skip the backward pass
-        create_layer: function for creating the layer, takes **kwargs
+        device: A torch.device
 
-    Returns: a tuple consisting of
-        Runtime as a float, and
-        Memory statistics as a dict
+    Returns:
+        max_memory_allocated before resetting the statistics and
+        memory_allocated, both in bytes
     """
+    prev_max_memory = torch.cuda.max_memory_allocated(device)
+    memory_allocated = torch.cuda.memory_allocated(device)
 
-    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    if prev_max_memory != memory_allocated and prev_max_memory > 0:
+        # raises RuntimeError if no previous allocation occurred
+        torch.cuda.reset_peak_memory_stats(device)
+        assert torch.cuda.max_memory_allocated(device) == memory_allocated
 
-    if torch.cuda.is_available():
-        assert reset_peak_memory_stats(device).cur_mem == 0
+    return Memory(prev_max_memory, memory_allocated)
 
-    # setup layer
-    layer_fun = create_layer(**kwargs)
 
+def get_layer_set(layer: str) -> str:
+    """Layers in the same layer set share a config.
+
+    Args:
+        layer: Full name of the layer. This will be the PyTorch or Opacus
+        name of the layer in lower case (e.g. linear, rnn, dprnn), prefixed with
+        gsm_ (e.g. gsm_linear, gsm_dprnn) if DP is enabled. MultiheadAttention
+        is abbreviated to mha.
+
+    Returns:
+        The name of the layer set, where a set of layers are defined as layers
+        that share the same __init__ signature.
+
+    Notes:
+        All RNN-based models share a config.
+
+    """
+    layer_set = layer.replace("gsm_dp", "").replace("gsm_", "").replace("dp", "")
+
+    # all RNN-based model use the same config
+    if layer_set in ["rnn", "gru", "lstm"]:
+        layer_set = "rnn_base"
+
+    return layer_set
+
+
+def get_path(
+    layer: LayerType,
+    batch_size: int,
+    num_runs: int,
+    num_repeats: int,
+    random_seed: Optional[int] = None,
+    forward_only: bool = False,
+    root: str = "./results/raw/",
+    suffix: str = "",
+) -> str:
+    """Gets the path to the file where the corresponding results are located.
+    File is presumed to be a pickle file.
+
+    Args:
+        layer: full layer name
+        batch_size: batch size
+        num_runs: number of runs per benchmark
+        num_repeats: how many benchmarks were run
+        random_seed: the initial random seed
+        forward_only: whether backward passes were skipped
+        root: directory to write results to
+        suffix: optional string to append to file name
+
+    Returns:
+        Path to results pickle file
+    """
+    pickle_name = f"{layer}_bs_{batch_size}_runs_{num_runs}_repeats_{num_repeats}_seed_{random_seed}"
     if forward_only:
-        layer_fun.module.eval()
-        benchmark_fun = layer_fun.forward_only
+        pickle_name += "_forward_only"
+
+    if len(suffix) and not suffix.startswith("_"):
+        suffix = f"_{suffix}"
+
+    return f"{root}{pickle_name}{suffix}.pkl"
+
+
+def save_results(
+    layer: LayerType,
+    batch_size: int,
+    num_runs: int,
+    num_repeats: int,
+    results: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    random_seed: Optional[int] = None,
+    forward_only: bool = False,
+    root: str = "./results/raw/",
+    suffix: str = "",
+) -> None:
+    """Saves the corresponding results as a pickle file.
+
+    Args:
+        layer: full layer name
+        batch_size: batch size
+        num_runs: number of runs per benchmark
+        num_repeats: how many benchmarks were run
+        runtimes: list of runtimes of length num_repeats
+        memory: list of memory stats of length num_repeats
+        config: layer config
+        random_seed: the initial random seed
+        forward_only: whether backward passes were skipped
+        root: directory to write results to
+        suffix: optional string to append to file name
+    """
+    path = get_path(
+        layer=layer,
+        batch_size=batch_size,
+        num_runs=num_runs,
+        num_repeats=num_repeats,
+        random_seed=random_seed,
+        forward_only=forward_only,
+        root=root,
+        suffix=suffix,
+    )
+
+    with open(path, "wb") as handle:
+        pickle.dump(
+            {
+                "layer": layer,
+                "batch_size": batch_size,
+                "num_runs": num_runs,
+                "num_repeats": num_repeats,
+                "random_seed": random_seed,
+                "forward_only": forward_only,
+                "results": results,
+                "config": config,
+            },
+            handle,
+            protocol=pickle.HIGHEST_PROTOCOL,
+        )
+
+
+def generate_report(path_to_results: str, save_path: str, format: str) -> None:
+    """Generate a report from the benchamrks outcome.
+    The output is a file whic contains the runtime and memory of each layer.
+    If multiple layer variants were run (pytorch nn, DP, or GSM).
+    Then we will compare the performance of both DP and GSM to pytorch.nn.
+
+    Args:
+        path_to_results: the path that `run_benchmarks.py` has saved results to.
+        save_path: path to save the output.
+        format: output format : csv or pkl.
+    """
+    path_to_results = (
+        path_to_results if path_to_results[-1] != "/" else path_to_results[:-1]
+    )
+    files = glob.glob(f"{path_to_results}/*")
+
+    if len(files) == 0:
+        raise Exception(f"There were no result files in the path {path_to_results}")
+
+    raw_results = []
+    for result_file in files:
+        with open(result_file, "rb") as handle:
+            raw_results.append(pickle.load(handle))
+
+    results_dict = []
+    for raw in raw_results:
+        runtime = np.mean([i["runtime"] for i in raw["results"]])
+        memory = np.mean([i["memory_stats"]["max_memory"] for i in raw["results"]])
+        result = {
+            "layer": raw["layer"],
+            "batch_size": raw["batch_size"],
+            "num_runs": raw["num_runs"],
+            "num_repeats": raw["num_repeats"],
+            "forward_only": raw["forward_only"],
+            "runtime": runtime,
+            "memory": memory,
+        }
+        results_dict.append(result)
+
+    results = pd.DataFrame(results_dict)
+    results["variant"] = "control"
+    results["variant"][results["layer"].str.startswith("gsm")] = "gsm"
+    results["variant"][results["layer"].str.startswith("dp")] = "dp"
+    results["base_layer"] = results["layer"].str.replace("(gsm_)|(dp)", "")
+
+    pivot = results.pivot_table(
+        index=["batch_size", "num_runs", "num_repeats", "forward_only", "base_layer"],
+        columns=["variant"],
+        values=["runtime", "memory"],
+    )
+
+    def add_ratio(df, metric, variant):
+        if variant in df.columns.get_level_values("variant"):
+            df[(metric, f"{variant}/control")] = (
+                df.loc[:, (metric, variant)] / df.loc[:, (metric, "control")]
+            )
+        else:
+            df[(metric, f"{variant}/control")] = np.nan
+
+    if "control" in results["variant"].tolist():
+        add_ratio(pivot, "runtime", "dp")
+        add_ratio(pivot, "memory", "dp")
+        add_ratio(pivot, "runtime", "gsm")
+        add_ratio(pivot, "memory", "gsm")
+        pivot.columns = pivot.columns.set_names("value", level=1)
+
+    output = pivot.sort_index(axis=1).sort_values(
+        ["batch_size", "num_runs", "num_repeats", "forward_only"]
+    )
+    if format == "csv":
+        output.to_csv(save_path)
     else:
-        layer_fun.module.train()
-        benchmark_fun = layer_fun.forward_backward
-
-    # move layer to device and get memory statistics
-    memory_stats = layer_fun.to(device=device)
-    assert sum(v for _, v in memory_stats.items()) == torch.cuda.memory_allocated(
-        device
-    )
-
-    # benchmark.Timer performs its own warmups
-    timer = benchmark.Timer(
-        stmt="benchmark_fun()",
-        globals={"benchmark_fun": benchmark_fun},
-        num_threads=1,
-    )
-    runtime = timer.timeit(num_repeats).mean
-
-    # get max memory allocated and reset memory statistics
-    memory_stats["max_memory"] = reset_peak_memory_stats(device).prev_max_mem
-
-    return runtime, memory_stats
-
-
-def main(args) -> None:
-
-    with open(args.config_file) as config_file:
-        config = json.load(config_file)
-
-    runtime, memory_stats = run_layer_benchmark(
-        num_repeats=args.num_repeats,
-        forward_only=args.forward_only,
-        layer_name=args.layer,
-        batch_size=args.batch_size,
-        random_seed=args.random_seed,
-        **config[get_layer_set(args.layer)],
-    )
-    print(f"Runtime (seconds): {runtime}")
-    print(f"Memory statistics (bytes): {memory_stats}")
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "layer",
-        type=str,
-        choices=[v for k, v in LayerType.__dict__.items() if not k.startswith("__")],
-    )
-    parser.add_argument("--batch_size", default=64, type=int)
-    parser.add_argument(
-        "--num_repeats",
-        default=20,
-        type=int,
-        help="number of forward/backward passes to run",
-    )
-    parser.add_argument(
-        "--forward_only", action="store_true", help="only run forward passes"
-    )
-    parser.add_argument("--random_seed", default=0, type=int)
-    parser.add_argument(
-        "-c",
-        "--config_file",
-        default="config.json",
-        type=str,
-        help="path to config file with settings for each layer",
-    )
-    args = parser.parse_args()
-    main(args)
+        output.to_pickle(save_path)

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pickle
 import glob
+import pickle
 from collections import namedtuple
 from typing import Any, Dict, List, Optional
 
-import torch
-from layers import LayerType
 import numpy as np
 import pandas as pd
+import torch
+
+from layers import LayerType
+
 
 Memory = namedtuple("Memory", "prev_max_mem, cur_mem")
 

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -220,12 +220,13 @@ def generate_report(path_to_results: str, save_path: str, format: str) -> None:
     )
 
     def add_ratio(df, metric, variant):
-        if variant in df.columns.get_level_values("variant"):
-            df[(metric, f"{variant}/control")] = (
-                df.loc[:, (metric, variant)] / df.loc[:, (metric, "control")]
-            )
-        else:
-            df[(metric, f"{variant}/control")] = np.nan
+        if variant not in df.columns.get_level_values("variant"):
+            for ametric in df.columns.get_level_values(0):
+                df[(ametric, variant)] = np.nan
+
+        df[(metric, f"{variant}/control")] = (
+            df.loc[:, (metric, variant)] / df.loc[:, (metric, "control")]
+        )
 
     if "control" in results["variant"].tolist():
         add_ratio(pivot, "runtime", "dp")

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -20,7 +20,6 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pandas as pd
 import torch
-
 from layers import LayerType
 
 


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

 Issue: https://github.com/pytorch/opacus/issues/368
## Motivation and Context / Related issue
There's a task #368 for committing benchmark code. In this change I add these benchmarks into CI integration tests. To choose thresholds I ran the benchmarks locally on all  the layers with (batch size: 16, num_runs: 100, num_repeats: 20, forward_only: False), please check the [comment below](https://github.com/pytorch/opacus/pull/481#issuecomment-1232704716) for more details.

Using the [report](https://github.com/pytorch/opacus/pull/481#issuecomment-1228317342) and section 3 in the [paper](https://arxiv.org/pdf/2109.12298.pdf), I parameterised the runtime and memory thresholds for different layers.

## How Has This Been Tested (if it applies)
 - I ran the jobs locally and generated reports.
 - Local CircleCI config validation `circleci config process .circleci/config.yml`
 - Local CircleCI job run: `circleci local execute --job JOB_NAME`
## Checklist

- [X] The documentation is up-to-date with the changes I made.
- [X] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
