### PR TITLE
Fixed typo in _replace_sub_module method in module_validator.py

### DIFF
--- a/opacus/validators/module_validator.py
+++ b/opacus/validators/module_validator.py
@@ -111,7 +111,7 @@ class ModuleValidator:
                 # move new_sub_module to the same device as that of sub_module
                 new_sub_module.to(next(sub_module.parameters()).device)
                 # get module after replacement.
-                module = cls._repalce_sub_module(
+                module = cls._replace_sub_module(
                     root=module,
                     sub_module_name=sub_module_name,
                     new_sub_module=new_sub_module,
@@ -125,7 +125,7 @@ class ModuleValidator:
         return module
 
     @classmethod
-    def _repalce_sub_module(
+    def _replace_sub_module(
         cls,
         *,
         root: nn.Module,
@@ -137,7 +137,7 @@ class ModuleValidator:
             len(sub_module_path) == 1 and sub_module_path[0] == ""
         ):  # root is the only sub_module of root
             return new_sub_module
-        else:  # repalce root's descendant
+        else:  # replace root's descendant
             sub_module_parent = root
             for name in sub_module_path[:-1]:  # descend down to sub_module
                 sub_module_parent = sub_module_parent._modules[name]


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
Fixed _replace_sub_module, which used to be _repalce_sub_module
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Related to issue https://github.com/pytorch/opacus/issues/380 but on methods

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
