### PR TITLE
Better validator for matching parameters

### DIFF
--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -86,11 +86,9 @@ class BasePrivacyEngineTest(ABC):
     ):
         model = self._init_model()
         optimizer = torch.optim.SGD(
-            [
-                p
-                for p in model.parameters()
-                if p.requires_grad or (not opt_exclude_frozen)
-            ],
+            model.parameters()
+            if not opt_exclude_frozen
+            else [p for p in model.parameters() if p.requires_grad],
             lr=self.LR,
             momentum=0,
         )
@@ -113,11 +111,9 @@ class BasePrivacyEngineTest(ABC):
         model = self._init_model()
         model = PrivacyEngine.get_compatible_module(model)
         optimizer = torch.optim.SGD(
-            [
-                p
-                for p in model.parameters()
-                if p.requires_grad or (not opt_exclude_frozen)
-            ],
+            model.parameters()
+            if not opt_exclude_frozen
+            else [p for p in model.parameters() if p.requires_grad],
             lr=self.LR,
             momentum=0,
         )


### PR DESCRIPTION
This PR resolves #477 and addresses various issues regarding parameter validation

## Background

As identified in #432, we want to warn the user if optimizer parameters are different from model parameters (e.g. because the module has been replaced by the ModuleValidator). Optimizer expects the weights to have `.grad_sample` attribute populated by the `GradSampleModule`, so there's no sense in having optimizer with different set of params to the input model

### Issue 1: Comparing values

One problem with how we do it currently is that we're looking for the wrong thing. We use `torch.eq`, which performs elementwise comparison and will output True for identical tensors. The problem is - we don't need identical, we need the *exact same object* - so that optimizer can read per-sample gradients computed by the GradSampleModule.

### Issue 2: Frozen layers

When freezing some model layers, people are free to choose how to initialize their optimizer: with all `model.parameters()` or only  those which are not frozen - it doesn't have any material difference on the training process.
However, if they do the latter, opacus will complain that model and optimizer weights are mismatched.

### This PR

In this PR we address both issues by:
1) Checking if the optimizer parameters is a *subset* of model parameters (not including some model params in the optimizer is perfectly fine)
2) using `in` operator, which checks object and not its value
3) Adding extra tests to cover issues described above