### PR TITLE
[functorch] No-Op GradSampleModule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,8 @@ commands:
             pip install tensorboard
             python examples/cifar10.py --lr 0.1 --sigma 1.5 -c 10 --batch-size 2000 --epochs 10 --data-root runs/cifar10/data --log-dir runs/cifar10/logs --device <<parameters.device>>
             python -c "import torch; model = torch.load('model_best.pth.tar'); exit(0) if (model['best_acc1']>0.4 and model['best_acc1']<0.49) else exit(1)"
+            python examples/cifar10.py --lr 0.1 --sigma 1.5 -c 10 --sample-rate 0.04 --epochs 10 --data-root runs/cifar10/data --log-dir runs/cifar10/logs --device <<parameters.device>> --grad_sample_mode no_op
+            python -c "import torch; model = torch.load('model_best.pth.tar'); exit(0) if (model['best_acc1']>0.4 and model['best_acc1']<0.49) else exit(1)"
           when: always
       - store_test_results:
           path: runs/cifar10/test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ commands:
             pip install tensorboard
             python examples/cifar10.py --lr 0.1 --sigma 1.5 -c 10 --batch-size 2000 --epochs 10 --data-root runs/cifar10/data --log-dir runs/cifar10/logs --device <<parameters.device>>
             python -c "import torch; model = torch.load('model_best.pth.tar'); exit(0) if (model['best_acc1']>0.4 and model['best_acc1']<0.49) else exit(1)"
-            python examples/cifar10.py --lr 0.1 --sigma 1.5 -c 10 --sample-rate 0.04 --epochs 10 --data-root runs/cifar10/data --log-dir runs/cifar10/logs --device <<parameters.device>> --grad_sample_mode no_op
+            python examples/cifar10.py --lr 0.1 --sigma 1.5 -c 10 --batch-size 2000 --epochs 10 --data-root runs/cifar10/data --log-dir runs/cifar10/logs --device <<parameters.device>> --grad_sample_mode no_op
             python -c "import torch; model = torch.load('model_best.pth.tar'); exit(0) if (model['best_acc1']>0.4 and model['best_acc1']<0.49) else exit(1)"
           when: always
       - store_test_results:

--- a/examples/cifar10.py
+++ b/examples/cifar10.py
@@ -31,7 +31,6 @@ import torch.optim as optim
 import torch.utils.data
 import torch.utils.data.distributed
 import torchvision.transforms as transforms
-from functorch import grad_and_value, make_functional, vmap
 from opacus import PrivacyEngine
 from opacus.distributed import DifferentiallyPrivateDistributedDataParallel as DPDDP
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -140,6 +139,8 @@ def train(args, model, train_loader, optimizer, privacy_engine, epoch, device):
     top1_acc = []
 
     if args.grad_sample_mode == "no_op":
+        from functorch import grad_and_value, make_functional, vmap
+
         # Functorch prepare
         fmodel, _fparams = make_functional(model)
 

--- a/opacus/grad_sample/gsm_no_op.py
+++ b/opacus/grad_sample/gsm_no_op.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn as nn
+from opacus.grad_sample.gsm_base import AbstractGradSampleModule
+
+
+class GradSampleModuleNoOp(AbstractGradSampleModule):
+    """
+    ExpandedWeights-based implementation of AbstractGradSampleModule
+
+    Computes per-sample gradients using PyTorch built-in mechanism of ExpandedWeights.
+    See README.md for more details
+    """
+
+    def __init__(
+        self,
+        m: nn.Module,
+        *,
+        batch_first=True,
+        loss_reduction="mean",
+    ):
+        if not batch_first:
+            raise NotImplementedError
+
+        super().__init__(
+            m,
+            batch_first=batch_first,
+            loss_reduction=loss_reduction,
+        )
+
+    def forward(self, x: torch.Tensor, *args, **kwargs):
+        return self._module.forward(x, *args, **kwargs)

--- a/opacus/grad_sample/gsm_no_op.py
+++ b/opacus/grad_sample/gsm_no_op.py
@@ -20,9 +20,8 @@ from opacus.grad_sample.gsm_base import AbstractGradSampleModule
 
 class GradSampleModuleNoOp(AbstractGradSampleModule):
     """
-    ExpandedWeights-based implementation of AbstractGradSampleModule
-
-    Computes per-sample gradients using PyTorch built-in mechanism of ExpandedWeights.
+    NoOp GradSampleModule.
+    Only wraps the module. The main goal of this class is to provide the same API for all methods.
     See README.md for more details
     """
 

--- a/opacus/grad_sample/utils.py
+++ b/opacus/grad_sample/utils.py
@@ -20,6 +20,7 @@ import torch.nn as nn
 from .grad_sample_module import GradSampleModule
 from .gsm_base import AbstractGradSampleModule
 from .gsm_exp_weights import GradSampleModuleExpandedWeights
+from .gsm_no_op import GradSampleModuleNoOp
 
 
 def register_grad_sampler(
@@ -69,6 +70,8 @@ def get_gsm_class(grad_sample_mode: str) -> Type[AbstractGradSampleModule]:
         return GradSampleModule
     elif grad_sample_mode == "ew":
         return GradSampleModuleExpandedWeights
+    elif grad_sample_mode == "no_op":
+        return GradSampleModuleNoOp
     else:
         raise ValueError(
             f"Unexpected grad_sample_mode: {grad_sample_mode}. "

--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -395,7 +395,7 @@ class DPOptimizer(Optimizer):
         """
 
         per_param_norms = [
-            g.norm(2, dim=tuple(range(1, g.ndim))) for g in self.grad_samples
+            g.view(len(g), -1).norm(2, dim=-1) for g in self.grad_samples
         ]
         per_sample_norms = torch.stack(per_param_norms, dim=1).norm(2, dim=1)
         per_sample_clip_factor = (self.max_grad_norm / (per_sample_norms + 1e-6)).clamp(

--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -395,7 +395,7 @@ class DPOptimizer(Optimizer):
         """
 
         per_param_norms = [
-            g.view(len(g), -1).norm(2, dim=-1) for g in self.grad_samples
+            g.reshape(len(g), -1).norm(2, dim=-1) for g in self.grad_samples
         ]
         per_sample_norms = torch.stack(per_param_norms, dim=1).norm(2, dim=1)
         per_sample_clip_factor = (self.max_grad_norm / (per_sample_norms + 1e-6)).clamp(


### PR DESCRIPTION
TL;DR: Adding a No-Op GradSampleModule in case the grad samples are computed by functorch. The CIFAR10 example has been updated to show a typical use-case for that.

The neat thing about functorch is that it directly gives the per-sample gradients with a couple of lines of code. These per-sample gradients are then manually given to `p.grad_sample` by the end-user.
