### PR TITLE
Functorch gradients: investigation and fix

### DIFF
--- a/opacus/grad_sample/functorch.py
+++ b/opacus/grad_sample/functorch.py
@@ -48,7 +48,7 @@ def ft_compute_per_sample_gradient(layer, activations, backprops):
         activations: the input to the layer
         backprops: the  gradient of the loss w.r.t. outputs of the layer
     """
-    parameters = list(layer.parameters())
+    parameters = list(layer.parameters(recurse=True))
     if not hasattr(layer, "ft_compute_sample_grad"):
         prepare_layer(layer)
 

--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -151,7 +151,7 @@ class GradSampleModule(AbstractGradSampleModule):
         if has_trainable_params(module):
             yield module
 
-        # we'll apply functorch for the entire substree
+        # Don't recurse if module is handled by functorch
         if (
             has_trainable_params(module)
             and type(module) not in self.GRAD_SAMPLERS

--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -160,7 +160,7 @@ class GradSampleModule(AbstractGradSampleModule):
             return
 
         for m in module.children():
-            yield from self.walk_with_functorch(m)
+            yield from self.iterate_submodules(m)
 
     def add_hooks(
         self,

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -32,7 +32,6 @@ from opacus.grad_sample.gsm_exp_weights import API_CUTOFF_VERSION
 from opacus.layers.dp_multihead_attention import DPMultiheadAttention
 from opacus.optimizers.optimizer import _generate_noise
 from opacus.scheduler import StepNoise
-from opacus.tests.utils import CustomLinearModule, LinearWithExtraParam
 from opacus.utils.module_utils import are_state_dict_equal
 from opacus.validators.errors import UnsupportedModuleError
 from opacus.validators.module_validator import ModuleValidator
@@ -40,6 +39,8 @@ from opt_einsum import contract
 from torch.utils.data import DataLoader, Dataset, TensorDataset
 from torchvision import models, transforms
 from torchvision.datasets import FakeData
+
+from .utils import CustomLinearModule, LinearWithExtraParam
 
 
 def _is_functorch_available():

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -662,70 +662,70 @@ class BasePrivacyEngineTest(ABC):
         if noise_scheduler:
             self.assertEqual(s2.state_dict(), s11.state_dict())
 
-    # @given(
-    #     noise_multiplier=st.floats(0.5, 5.0),
-    #     max_steps=st.integers(8, 10),
-    #     secure_mode=st.just(False),  # TODO: enable after fixing torchcsprng build
-    # )
-    # @settings(deadline=None)
-    # def test_noise_level(
-    #     self,
-    #     noise_multiplier: float,
-    #     max_steps: int,
-    #     secure_mode: bool,
-    # ):
-    #     """
-    #     Tests that the noise level is correctly set
-    #     """
-    #
-    #     def helper_test_noise_level(
-    #         noise_multiplier: float, max_steps: int, secure_mode: bool
-    #     ):
-    #         torch.manual_seed(100)
-    #         # Initialize models with parameters to zero
-    #         model, optimizer, dl, _ = self._init_private_training(
-    #             noise_multiplier=noise_multiplier,
-    #             secure_mode=secure_mode,
-    #             grad_sample_mode=self.GRAD_SAMPLE_MODE,
-    #         )
-    #         for p in model.parameters():
-    #             p.data.zero_()
-    #
-    #         # Do max_steps steps of DP-SGD
-    #         n_params = sum([p.numel() for p in model.parameters() if p.requires_grad])
-    #         steps = 0
-    #         for x, _y in dl:
-    #             optimizer.zero_grad()
-    #             logits = model(x)
-    #             loss = logits.view(logits.size(0), -1).sum(dim=1)
-    #             # Gradient should be 0
-    #             loss.backward(torch.zeros(logits.size(0)))
-    #
-    #             optimizer.step()
-    #             steps += 1
-    #
-    #             if max_steps and steps >= max_steps:
-    #                 break
-    #
-    #         # Noise should be equal to lr*sigma*sqrt(n_params * steps) / batch_size
-    #         expected_norm = (
-    #             steps
-    #             * n_params
-    #             * optimizer.noise_multiplier**2
-    #             * self.LR**2
-    #             / (optimizer.expected_batch_size**2)
-    #         )
-    #         real_norm = sum(
-    #             [torch.sum(torch.pow(p.data, 2)) for p in model.parameters()]
-    #         ).item()
-    #
-    #         self.assertAlmostEqual(real_norm, expected_norm, delta=0.15 * expected_norm)
-    #
-    #     helper_test_noise_level(
-    #         noise_multiplier=noise_multiplier,
-    #         max_steps=max_steps,
-    #         secure_mode=secure_mode,
-    #     )
+    @given(
+        noise_multiplier=st.floats(0.5, 5.0),
+        max_steps=st.integers(8, 10),
+        secure_mode=st.just(False),  # TODO: enable after fixing torchcsprng build
+    )
+    @settings(deadline=None)
+    def test_noise_level(
+        self,
+        noise_multiplier: float,
+        max_steps: int,
+        secure_mode: bool,
+    ):
+        """
+        Tests that the noise level is correctly set
+        """
+
+        def helper_test_noise_level(
+            noise_multiplier: float, max_steps: int, secure_mode: bool
+        ):
+            torch.manual_seed(100)
+            # Initialize models with parameters to zero
+            model, optimizer, dl, _ = self._init_private_training(
+                noise_multiplier=noise_multiplier,
+                secure_mode=secure_mode,
+                grad_sample_mode=self.GRAD_SAMPLE_MODE,
+            )
+            for p in model.parameters():
+                p.data.zero_()
+
+            # Do max_steps steps of DP-SGD
+            n_params = sum([p.numel() for p in model.parameters() if p.requires_grad])
+            steps = 0
+            for x, _y in dl:
+                optimizer.zero_grad()
+                logits = model(x)
+                loss = logits.view(logits.size(0), -1).sum(dim=1)
+                # Gradient should be 0
+                loss.backward(torch.zeros(logits.size(0)))
+
+                optimizer.step()
+                steps += 1
+
+                if max_steps and steps >= max_steps:
+                    break
+
+            # Noise should be equal to lr*sigma*sqrt(n_params * steps) / batch_size
+            expected_norm = (
+                steps
+                * n_params
+                * optimizer.noise_multiplier**2
+                * self.LR**2
+                / (optimizer.expected_batch_size**2)
+            )
+            real_norm = sum(
+                [torch.sum(torch.pow(p.data, 2)) for p in model.parameters()]
+            ).item()
+
+            self.assertAlmostEqual(real_norm, expected_norm, delta=0.15 * expected_norm)
+
+        helper_test_noise_level(
+            noise_multiplier=noise_multiplier,
+            max_steps=max_steps,
+            secure_mode=secure_mode,
+        )
 
     @unittest.skip("requires torchcsprng compatible with new pytorch versions")
     @patch("torch.normal", MagicMock(return_value=torch.Tensor([0.6])))

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -1007,6 +1007,7 @@ class ModelWithCustomLinear(nn.Module):
         return x
 
 
+@unittest.skipIf(not _is_functorch_available(), "not supported in this torch version")
 class PrivacyEngineCustomLayerTest(BasePrivacyEngineTest, unittest.TestCase):
     def _init_data(self):
         ds = TensorDataset(

--- a/opacus/tests/privacy_engine_validation_test.py
+++ b/opacus/tests/privacy_engine_validation_test.py
@@ -3,13 +3,14 @@ import unittest
 import torch
 from opacus import PrivacyEngine
 from opacus.grad_sample.gsm_exp_weights import API_CUTOFF_VERSION
-from opacus.tests.utils import (
+from torch.utils.data import DataLoader
+
+from .utils import (
     BasicSupportedModule,
     CustomLinearModule,
     LinearWithExtraParam,
     MatmulModule,
 )
-from torch.utils.data import DataLoader
 
 
 class PrivacyEngineValidationTest(unittest.TestCase):

--- a/opacus/tests/privacy_engine_validation_test.py
+++ b/opacus/tests/privacy_engine_validation_test.py
@@ -6,53 +6,7 @@ import torch.nn.functional as F
 from opacus import PrivacyEngine
 from opacus.grad_sample.gsm_exp_weights import API_CUTOFF_VERSION
 from torch.utils.data import DataLoader
-
-
-class BasicSupportedModule(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.conv = nn.Conv1d(in_channels=16, out_channels=8, kernel_size=2)
-        self.gn = nn.GroupNorm(num_groups=2, num_channels=8)
-        self.fc = nn.Linear(in_features=4, out_features=8)
-        self.ln = nn.LayerNorm([8, 8])
-
-    def forward(self, x):
-        x = self.conv(x)
-        x = self.gn(x)
-        x = self.fc(x)
-        x = self.ln(x)
-        return x
-
-
-class CustomLinearModule(nn.Module):
-    def __init__(self, in_features, out_features):
-        super().__init__()
-        self._weight = nn.Parameter(torch.randn(out_features, in_features))
-        self._bias = nn.Parameter(torch.randn(out_features))
-
-    def forward(self, x):
-        return F.linear(x, self._weight, self._bias)
-
-
-class MatmulModule(nn.Module):
-    def __init__(self, input_features, output_features):
-        super().__init__()
-        self.weight = nn.Parameter(torch.randn(input_features, output_features))
-
-    def forward(self, x):
-        return torch.matmul(x, self.weight)
-
-
-class LinearWithExtraParam(nn.Module):
-    def __init__(self, in_features, out_features):
-        super().__init__()
-        self.fc = nn.Linear(in_features, out_features)
-        self.extra_param = nn.Parameter(torch.randn(out_features, 2))
-
-    def forward(self, x):
-        x = self.fc(x)
-        x = x.matmul(self.extra_param)
-        return x
+from opacus.tests.utils import BasicSupportedModule, CustomLinearModule, LinearWithExtraParam, MatmulModule
 
 
 class PrivacyEngineValidationTest(unittest.TestCase):

--- a/opacus/tests/privacy_engine_validation_test.py
+++ b/opacus/tests/privacy_engine_validation_test.py
@@ -1,12 +1,15 @@
 import unittest
 
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
 from opacus import PrivacyEngine
 from opacus.grad_sample.gsm_exp_weights import API_CUTOFF_VERSION
+from opacus.tests.utils import (
+    BasicSupportedModule,
+    CustomLinearModule,
+    LinearWithExtraParam,
+    MatmulModule,
+)
 from torch.utils.data import DataLoader
-from opacus.tests.utils import BasicSupportedModule, CustomLinearModule, LinearWithExtraParam, MatmulModule
 
 
 class PrivacyEngineValidationTest(unittest.TestCase):

--- a/opacus/tests/utils.py
+++ b/opacus/tests/utils.py
@@ -1,0 +1,49 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class BasicSupportedModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv1d(in_channels=16, out_channels=8, kernel_size=2)
+        self.gn = nn.GroupNorm(num_groups=2, num_channels=8)
+        self.fc = nn.Linear(in_features=4, out_features=8)
+        self.ln = nn.LayerNorm([8, 8])
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.gn(x)
+        x = self.fc(x)
+        x = self.ln(x)
+        return x
+
+
+class CustomLinearModule(nn.Module):
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self._weight = nn.Parameter(torch.randn(out_features, in_features))
+        self._bias = nn.Parameter(torch.randn(out_features))
+
+    def forward(self, x):
+        return F.linear(x, self._weight, self._bias)
+
+
+class MatmulModule(nn.Module):
+    def __init__(self, input_features: int, output_features: int):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(input_features, output_features))
+
+    def forward(self, x):
+        return torch.matmul(x, self.weight)
+
+
+class LinearWithExtraParam(nn.Module):
+    def __init__(self, in_features: int, out_features: int, hidden_dim:int = 8):
+        super().__init__()
+        self.fc = nn.Linear(in_features, hidden_dim)
+        self.extra_param = nn.Parameter(torch.randn(hidden_dim, out_features))
+
+    def forward(self, x):
+        x = self.fc(x)
+        x = x.matmul(self.extra_param)
+        return x

--- a/opacus/tests/utils.py
+++ b/opacus/tests/utils.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+
 class BasicSupportedModule(nn.Module):
     def __init__(self):
         super().__init__()
@@ -38,7 +39,7 @@ class MatmulModule(nn.Module):
 
 
 class LinearWithExtraParam(nn.Module):
-    def __init__(self, in_features: int, out_features: int, hidden_dim:int = 8):
+    def __init__(self, in_features: int, out_features: int, hidden_dim: int = 8):
         super().__init__()
         self.fc = nn.Linear(in_features, hidden_dim)
         self.extra_param = nn.Parameter(torch.randn(hidden_dim, out_features))

--- a/opacus/utils/module_utils.py
+++ b/opacus/utils/module_utils.py
@@ -31,7 +31,11 @@ logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
 
 
-def parametrized_modules(module: nn.Module) -> Iterable[nn.Module]:
+def has_trainable_params(module: nn.Module) -> bool:
+    return any(p.requires_grad for p in module.parameters(recurse=False))
+
+
+def parametrized_modules(module: nn.Module) -> Iterable[Tuple[str, nn.Module]]:
     """
     Recursively iterates over all submodules, returning those that
     have parameters (as opposed to "wrapper modules" that just organize modules).


### PR DESCRIPTION
*The investigation part for this PR was done by @alexandresablayrolles, thanks for figuring out the reason the tests were failing*

## Background
Current implementation of functorch-based per sample gradients fails on modules which have both trainable non-recursive parameters and standard submodules, e.g. below
```
class LinearWithExtraParam(nn.Module):
    def __init__(self, in_features: int, out_features: int, hidden_dim: int = 8):
        super().__init__()
        self.fc = nn.Linear(in_features, hidden_dim)
        self.extra_param = nn.Parameter(torch.randn(hidden_dim, out_features))

    def forward(self, x):
        x = self.fc(x)
        x = x.matmul(self.extra_param)
        return x
```

The reason is - functorch hook actually computes gradients for recursive submodules too. The problem is, normal hooks are also attached to these submodules. GradSampleModule then sees two grad_sample tensors, thinks it needs to accumulate and adds them up together

## Solution(s)

There are essentially two ways we can fix this: either make functorch compute per sample gradients for non-recursive parameters only or don't attach normal hooks to submodules where the parent module is handled by functorch.

This diff implements the latter option (reasoning below), for demo purposes the former option can be seen in #531 

For the pure code perspective the former option (let's call it "non-recursive functorch") is more appealing to me. It better fits the existing paradigm and matches normal hooks behaviour - all of the existing code only deals with the immediate non-recursive parameters.
However, it doesn't make much sense from the efficiency perspective. "non-recursive functorch" would do all the work to compute per-sample gradients for its submodules, only for them to be filtered out at the very last stage. 
Alternative option (a.k.a. "functorch for subtrees") does involve a bit more convoluted 

This has a noticeable effect on performance.
Below is the results of MNIST benchmarks with different configurations. I've tested this with different configurations, because at the end of the day, the impact on performance depends on how deep are subtrees 


* Standard model- our model from MNIST example, standard layers only (2 conv + 2 linear). No overhead expected, functorch doesn't kick in
* Mid-level model - leaf nodes (two linear layers) have one extra param and are computed with functorch. Overhead: 2x Linear hook
* Extreme model - root model have one extra param and needs to be handled by functorch. Overhead: 2x linear hook + 2x conv hook

| Mode                               | non-recursive functorch | functorch for subtrees |
|:-----------------------:|:------------------------:|:-----------------------:|
| Standard model (CPU)  |  138s                                 | 136s                                |
| Standard model (GPU)  |  149s                                 | 150s                                |
| Mid-level model (CPU)  |  157s                                 | 150s                                |
| Mid-level model (GPU)  |  100s                                 | 97s                                 |
| Extreme model (CPU)    |  207s                                 | 172s                               |
| Extreme model (GPU)    |  101s                                 | 94s                                |
