### PR TITLE
Conv3d test fix

### DIFF
--- a/opacus/tests/grad_samples/conv3d_test.py
+++ b/opacus/tests/grad_samples/conv3d_test.py
@@ -18,12 +18,13 @@ from typing import Tuple, Union
 import hypothesis.strategies as st
 import torch
 import torch.nn as nn
-from hypothesis import given, settings
+from hypothesis import given, settings, reproduce_failure
 
 from .common import GradSampleHooks_test, expander, shrinker
 
 
 class Conv3d_test(GradSampleHooks_test):
+
     @given(
         N=st.integers(1, 4),
         C=st.sampled_from([1, 3, 32]),
@@ -71,7 +72,7 @@ class Conv3d_test(GradSampleHooks_test):
             groups=groups,
         )
         is_ew_compatible = (
-            dilation == 1 or padding != "same"
+            dilation == 1 and padding != "same"
         )  # TODO add support for padding = 'same' with EW
         self.run_test(
             x,

--- a/opacus/tests/grad_samples/conv3d_test.py
+++ b/opacus/tests/grad_samples/conv3d_test.py
@@ -18,13 +18,12 @@ from typing import Tuple, Union
 import hypothesis.strategies as st
 import torch
 import torch.nn as nn
-from hypothesis import given, settings, reproduce_failure
+from hypothesis import given, settings
 
 from .common import GradSampleHooks_test, expander, shrinker
 
 
 class Conv3d_test(GradSampleHooks_test):
-
     @given(
         N=st.integers(1, 4),
         C=st.sampled_from([1, 3, 32]),


### PR DESCRIPTION
Conv3d grad sample test is failing currently: [CircleCI](https://app.circleci.com/pipelines/github/pytorch/opacus/2338/workflows/3a81554c-f5d7-49cf-b638-234c47d7ef67/jobs/13091/tests#failed-test-0)

This is most likely due to a difference in `unfold3d` method between opacus and EW implementations.

Opacus:
```
if dilation != (1, 1, 1):
    tensor = filter_dilated_rows(tensor, dilation, dilated_kernel_size, kernel_size)
```

EW:
```
if dilation != (1, 1, 1):
    raise NotImplementedError(f"dilation={dilation} not supported.")
```

As dilation other than 1 is not supported under any conditions with EW, I've fixed then`is_ew_compatible` flag.

PS: @ashkan-software do we have a github issue to update EW's `unfold3d` with the recent updates you made? 