### PR TITLE
Make DPMultiheadAttention drop-in compatible with nn.MultiheadAttention

### DIFF
--- a/opacus/layers/dp_multihead_attention.py
+++ b/opacus/layers/dp_multihead_attention.py
@@ -110,8 +110,6 @@ class DPMultiheadAttention(nn.Module):
         self.klinear = nn.Linear(self.kdim, embed_dim, bias=bias)
         self.vlinear = nn.Linear(self.vdim, embed_dim, bias=bias)
 
-        # torch.nn.MultiHeadAttention out_proj is _LinearWithBias
-        # explicilty setting bias=True for consistent mimicry
         self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
 
         self.add_bias_kv = add_bias_kv

--- a/opacus/tests/dp_layers/common.py
+++ b/opacus/tests/dp_layers/common.py
@@ -244,7 +244,7 @@ class DPModules_test(unittest.TestCase):
                 f"{i}. {s}" for i, s in enumerate(nn_only_grads, 1)
             )
             raise AssertionError(
-                f"A total of {len(nn_only_grads)} gradients are in dp_module "
+                f"A total of {len(dp_only_grads)} gradients are in dp_module "
                 f"but not in nn_module: \n\t{failed_str}"
             )
 

--- a/opacus/tests/dp_layers/dp_multihead_attention_test.py
+++ b/opacus/tests/dp_layers/dp_multihead_attention_test.py
@@ -51,9 +51,6 @@ class DPMultiheadAttention_test(DPModules_test):
         vdim=st.integers(2, 8) | st.none(),
     )
     @settings(deadline=10000)
-    @pytest.mark.skip(
-        "Failing due to a known problem. Should be enabled after issue #123 is fixed"
-    )
     def test_attn(
         self,
         batch_size: int,

--- a/opacus/tests/validators/multihead_attention_test.py
+++ b/opacus/tests/validators/multihead_attention_test.py
@@ -36,6 +36,6 @@ class MultiheadAttentionValidator_test(unittest.TestCase):
     def test_fix(self):
         fix_mha = self.mf[type(self.mha)](self.mha)
         self.assertTrue(isinstance(fix_mha, DPMultiheadAttention))
-        self.assertFalse(  # state_dicts are not same
+        self.assertTrue(
             are_state_dict_equal(self.mha.state_dict(), fix_mha.state_dict())
         )


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend having an existing issue for each pull request) -->

This PR is target to resolve #123 by having an additional re-naming mechanism to match the `state_dict` structure of `nn.MultiheadAttention`.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

Run `pytest` within the `opacus` folder:

```
============= 162 passed, 41 skipped, 4411 warnings in 243.18s (0:04:03) =============
```

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
