### PR TITLE
Make DPMultiheadAttention drop-in compatible with nn.MultiheadAttention

### DIFF
--- a/opacus/layers/dp_multihead_attention.py
+++ b/opacus/layers/dp_multihead_attention.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import warnings
+from collections import OrderedDict
 
 import torch
 import torch.nn as nn
@@ -88,11 +89,14 @@ class DPMultiheadAttention(nn.Module):
         add_zero_attn=False,
         kdim=None,
         vdim=None,
+        device=None,
+        dtype=None,
     ):
         super(DPMultiheadAttention, self).__init__()
         self.embed_dim = embed_dim
         self.kdim = kdim if kdim is not None else embed_dim
         self.vdim = vdim if vdim is not None else embed_dim
+        self._qkv_same_embed_dim = self.kdim == embed_dim and self.vdim == embed_dim
 
         self.num_heads = num_heads
         self.dropout = dropout
@@ -105,9 +109,7 @@ class DPMultiheadAttention(nn.Module):
         self.klinear = nn.Linear(self.kdim, embed_dim, bias=bias)
         self.vlinear = nn.Linear(self.vdim, embed_dim, bias=bias)
 
-        # torch.nn.MultiHeadAttention out_proj is _LinearWithBias
-        # explicilty setting bias=True for consistent mimicry
-        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=True)
+        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
 
         self.add_bias_kv = add_bias_kv
         if self.add_bias_kv:
@@ -329,3 +331,89 @@ class DPMultiheadAttention(nn.Module):
             return attn_output, attn_output_weights.sum(dim=1) / self.num_heads
         else:
             return attn_output, None
+
+    def unsqueeze_0_2(self, t):
+        return torch.unsqueeze(torch.unsqueeze(t, 0), 0)
+
+    def state_dict(self, destination=None, prefix="", keep_vars=False):
+        if destination is None:
+            destination = OrderedDict()
+            destination._metadata = OrderedDict()
+
+        local_metadata = dict(version=self._version)
+        if hasattr(destination, "_metadata"):
+            destination._metadata[prefix[:-1]] = local_metadata
+
+        destination_alter = OrderedDict()
+        if len(prefix.split(".")) > 2:
+            alter_key = ".".join(prefix.split(".")[:-2]) + ".emb.weight"
+        else:
+            alter_key = "emb.weight"
+        if alter_key in destination:
+            destination_alter[alter_key] = destination[alter_key]
+
+        self._save_to_state_dict(destination, prefix, keep_vars)
+        for name, module in self._modules.items():
+            if module is not None:
+                module.state_dict(
+                    destination=destination,
+                    prefix=prefix + name + ".",
+                    keep_vars=keep_vars,
+                )
+
+        if self._qkv_same_embed_dim:
+            destination_alter[prefix + "in_proj_weight"] = torch.cat(
+                (
+                    destination[prefix + "qlinear.weight"],
+                    destination[prefix + "klinear.weight"],
+                    destination[prefix + "vlinear.weight"],
+                ),
+                0,
+            )
+        else:
+            destination_alter[prefix + "q_proj_weight"] = destination[
+                prefix + "qlinear.weight"
+            ]
+            destination_alter[prefix + "k_proj_weight"] = destination[
+                prefix + "klinear.weight"
+            ]
+            destination_alter[prefix + "v_proj_weight"] = destination[
+                prefix + "vlinear.weight"
+            ]
+
+        if (
+            (prefix + "qlinear.bias") in destination
+            and (prefix + "klinear.bias") in destination
+            and (prefix + "vlinear.bias") in destination
+        ):
+            destination_alter[prefix + "in_proj_bias"] = torch.cat(
+                (
+                    destination[prefix + "qlinear.bias"],
+                    destination[prefix + "klinear.bias"],
+                    destination[prefix + "vlinear.bias"],
+                ),
+                0,
+            )
+
+        if self.add_bias_kv:
+            destination_alter[prefix + "bias_k"] = self.unsqueeze_0_2(
+                destination[prefix + "seq_bias_k.bias"]
+            )
+            destination_alter[prefix + "bias_v"] = self.unsqueeze_0_2(
+                destination[prefix + "seq_bias_v.bias"]
+            )
+
+        destination_alter[prefix + "out_proj.weight"] = destination[
+            prefix + "out_proj.weight"
+        ]
+        if (prefix + "out_proj.bias") in destination:
+            destination_alter[prefix + "out_proj.bias"] = destination[
+                prefix + "out_proj.bias"
+            ]
+
+        for hook in self._state_dict_hooks.values():
+            hook_result = hook(self, destination_alter, prefix, local_metadata)
+            if hook_result is not None:
+                destination_alter = hook_result
+
+        return destination_alter

--- a/opacus/tests/dp_layers/common.py
+++ b/opacus/tests/dp_layers/common.py
@@ -217,8 +217,8 @@ class DPModules_test(unittest.TestCase):
         train_fn(nn_module, *train_fn_args, **train_fn_kwargs)
         train_fn(dp_module, *train_fn_args, **train_fn_kwargs)
 
-        nn_params = dict(nn_module.named_parameters())
-        dp_params = dict(dp_module.named_parameters())
+        nn_params = nn_module.state_dict()
+        dp_params = dp_module.state_dict()
 
         nn_only_grads = [
             param_name
@@ -244,11 +244,11 @@ class DPModules_test(unittest.TestCase):
                 f"{i}. {s}" for i, s in enumerate(nn_only_grads, 1)
             )
             raise AssertionError(
-                f"A total of {len(nn_only_grads)} gradients are in dp_module "
+                f"A total of {len(dp_only_grads)} gradients are in dp_module "
                 f"but not in nn_module: \n\t{failed_str}"
             )
 
-        for param_name, nn_param in nn_module.named_parameters():
+        for param_name, nn_param in nn_params.items():
             dp_param = dp_params[param_name]
             self._check_shapes((nn_param), (dp_param), (param_name))
             self._check_values((nn_param), (dp_param), atol, rtol, (param_name))

--- a/opacus/tests/dp_layers/dp_multihead_attention_test.py
+++ b/opacus/tests/dp_layers/dp_multihead_attention_test.py
@@ -16,13 +16,20 @@
 from typing import Optional
 
 import hypothesis.strategies as st
-import pytest
 import torch
 import torch.nn as nn
 from hypothesis import given, settings
 from opacus.layers import DPMultiheadAttention
 
 from .common import DPModules_test
+
+
+def remove_in_proj_bias_hook(self, state_dict, prefix, local_metadata):
+    return {
+        param_name: param_value
+        for param_name, param_value in state_dict.items()
+        if param_name != "in_proj_bias"
+    }
 
 
 def attn_train_fn(
@@ -51,9 +58,6 @@ class DPMultiheadAttention_test(DPModules_test):
         vdim=st.integers(2, 8) | st.none(),
     )
     @settings(deadline=10000)
-    @pytest.mark.skip(
-        "Failing due to a known problem. Should be enabled after issue #123 is fixed"
-    )
     def test_attn(
         self,
         batch_size: int,
@@ -126,3 +130,130 @@ class DPMultiheadAttention_test(DPModules_test):
             need_weights=True,
             attn_mask=None,
         )
+
+    @given(
+        batch_size=st.integers(1, 5),
+        src_seq_len=st.integers(1, 6),
+        tgt_seq_len=st.integers(1, 6),
+        num_heads=st.integers(1, 3),
+        bias=st.booleans(),
+        add_bias_kv=st.booleans(),
+        add_zero_attn=st.booleans(),
+        kdim=st.integers(2, 8) | st.none(),
+        vdim=st.integers(2, 8) | st.none(),
+    )
+    @settings(deadline=10000)
+    def test_dp_attn(
+        self,
+        batch_size: int,
+        src_seq_len: int,
+        tgt_seq_len: int,
+        num_heads: int,
+        bias: bool,
+        add_bias_kv: bool,
+        add_zero_attn: bool,
+        kdim: Optional[int],
+        vdim: Optional[int],
+    ):
+        embed_dim = 4 * num_heads  # embed_dim must be divisible by num_heads
+
+        attn = nn.MultiheadAttention(
+            embed_dim,
+            num_heads,
+            dropout=0.0,  # Untestable between two different implementations
+            bias=bias,
+            add_bias_kv=add_bias_kv,
+            add_zero_attn=add_zero_attn,
+            kdim=kdim,
+            vdim=vdim,
+        )
+        dp_attn = DPMultiheadAttention(
+            embed_dim,
+            num_heads,
+            dropout=0.0,  # Untestable between two different implementations
+            bias=bias,
+            add_bias_kv=add_bias_kv,
+            add_zero_attn=add_zero_attn,
+            kdim=kdim,
+            vdim=vdim,
+        )
+
+        attn.load_state_dict(dp_attn.state_dict())
+
+        q = torch.randn(tgt_seq_len, batch_size, embed_dim)
+        k = torch.randn(
+            src_seq_len, batch_size, kdim if kdim is not None else embed_dim
+        )
+        v = torch.randn(
+            src_seq_len, batch_size, vdim if vdim is not None else embed_dim
+        )
+
+        self.compare_forward_outputs(
+            attn,
+            dp_attn,
+            q,
+            k,
+            v,
+            output_names=("attn_out", "attn_out_weights"),
+            atol=1e-5,
+            rtol=1e-3,
+            key_padding_mask=None,
+            need_weights=True,
+            attn_mask=None,
+        )
+
+        self.compare_gradients(
+            attn,
+            dp_attn,
+            attn_train_fn,
+            q,
+            k,
+            v,
+            atol=1e-5,
+            rtol=1e-3,
+            key_padding_mask=None,
+            need_weights=True,
+            attn_mask=None,
+        )
+
+    @given(
+        batch_size=st.integers(1, 5),
+        src_seq_len=st.integers(1, 6),
+        tgt_seq_len=st.integers(1, 6),
+        num_heads=st.integers(1, 3),
+        bias=st.booleans(),
+        add_bias_kv=st.booleans(),
+        add_zero_attn=st.booleans(),
+        kdim=st.integers(2, 8) | st.none(),
+        vdim=st.integers(2, 8) | st.none(),
+    )
+    @settings(deadline=10000)
+    def test_dp_attn_hook(
+        self,
+        batch_size: int,
+        src_seq_len: int,
+        tgt_seq_len: int,
+        num_heads: int,
+        bias: bool,
+        add_bias_kv: bool,
+        add_zero_attn: bool,
+        kdim: Optional[int],
+        vdim: Optional[int],
+    ):
+        embed_dim = 4 * num_heads  # embed_dim must be divisible by num_heads
+
+        dp_attn = DPMultiheadAttention(
+            embed_dim,
+            num_heads,
+            dropout=0.0,  # Untestable between two different implementations
+            bias=bias,
+            add_bias_kv=add_bias_kv,
+            add_zero_attn=add_zero_attn,
+            kdim=kdim,
+            vdim=vdim,
+        )
+
+        # Test if the hook function is working within the state_dict
+        if "in_proj_bias" in dp_attn.state_dict():
+            dp_attn._register_state_dict_hook(remove_in_proj_bias_hook)
+            self.assertFalse("in_proj_bias" in dp_attn.state_dict())

--- a/opacus/tests/validators/multihead_attention_test.py
+++ b/opacus/tests/validators/multihead_attention_test.py
@@ -36,6 +36,6 @@ class MultiheadAttentionValidator_test(unittest.TestCase):
     def test_fix(self):
         fix_mha = self.mf[type(self.mha)](self.mha)
         self.assertTrue(isinstance(fix_mha, DPMultiheadAttention))
-        self.assertFalse(  # state_dicts are not same
+        self.assertTrue(
             are_state_dict_equal(self.mha.state_dict(), fix_mha.state_dict())
         )


### PR DESCRIPTION
Summary: This PR is target to resolve #123 on GitHub by having an additional re-naming mechanism to match the `state_dict` structure of `nn.MultiheadAttention`.

Differential Revision: D40671870

