### PR TITLE
Update FAQ to meet current api

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -98,7 +98,7 @@ Assuming that batches are randomly selected, an increase in the batch size incre
 
 ## My model throws IncompatibleModuleException. What is going wrong?
 
-Your model most likely contains modules that are not compatible with Opacus. The most prominent example of these modules is batch-norm types. Luckily there is a good substitute for a `BatchNorm` layer, and it is called `GroupNorm`. You can convert all your batch norm submodules using this utility function: `opacus.utils.module_modification.convert_batchnorm_modules.`
+Your model most likely contains modules that are not compatible with Opacus. The most prominent example of these modules is batch-norm types. Before validating you model try to fix incompatible modules using `ModuleValidator.fix(model)` as described [here](https://opacus.ai/tutorials/guide_to_module_validator#Registering-fixer).
 
 ## What is virtual batch size?
 


### PR DESCRIPTION
Update hint for fixing `IncompatibleModuleException` from deprecated `opacus.utils.module_modification.convert_batchnorm_modules` to `ModuleValidator.fix()`

## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
outdated FAQ
<!--- Please link to an existing issue here if one exists. -->
https://discuss.pytorch.org/t/convert-batchnorm-modules-does-not-exist/157156/3
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
