### PR TITLE
Change z in PRV accountant to remove Userwarning for log(x<0)

### DIFF
--- a/opacus/accountants/analysis/prv/prvs.py
+++ b/opacus/accountants/analysis/prv/prvs.py
@@ -47,7 +47,9 @@ class PoissonSubsampledGaussianPRV:
         q = self.sample_rate
         sigma = self.noise_multiplier
 
-        z = np.log((np.exp(t) + q - 1) / q)
+        # z doesn't matter if t <= log(1-q)
+        # this is to avoid userwarning if argument to log is <0
+        z = np.log(np.where(t > np.log(1 - q), (np.exp(t) + q - 1) / q, 1))
 
         return np.where(
             t > np.log(1 - q),


### PR DESCRIPTION
Change definition of `z = np.log((np.exp(t) + q - 1) / q)` to `z = np.log(np.where(t > np.log(1 - q), (np.exp(t) + q - 1) / q, 1))` to avoid userwarning in PRV.