### PR TITLE
Pass `num_groups` arg to ModelValidator.fix

### DIFF
--- a/opacus/tests/module_validator_test.py
+++ b/opacus/tests/module_validator_test.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 import unittest
+from collections import OrderedDict
 
 import torch
 import torch.nn as nn
-from opacus.tests.utils import BasicBatchNormModel
 from opacus.validators.errors import UnsupportedModuleError
 from opacus.validators.module_validator import ModuleValidator
 from torchvision.models import mobilenet_v3_small
@@ -137,7 +137,15 @@ class ModuleValidator_test(unittest.TestCase):
         self.assertTrue(ModuleValidator.is_valid(model))
 
     def test_fix_bn_with_args(self):
-        m = BasicBatchNormModel()
+        m = nn.Sequential(
+            OrderedDict(
+                [
+                    ("fc", nn.Linear(4, 8)),
+                    ("bn", nn.BatchNorm2d(16)),
+                ]
+            )
+        )
+
         m1 = ModuleValidator.fix(m)
         self.assertTrue(isinstance(m1.bn, nn.GroupNorm))
         self.assertEqual(m1.bn.num_groups, 16)

--- a/opacus/tests/utils.py
+++ b/opacus/tests/utils.py
@@ -19,6 +19,18 @@ class BasicSupportedModule(nn.Module):
         return x
 
 
+class BasicBatchNormModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(4, 8)
+        self.bn = nn.BatchNorm2d(16)
+
+    def forward(self, x):
+        x = self.fc(x)
+        x = self.bn(x)
+        return x
+
+
 class CustomLinearModule(nn.Module):
     def __init__(self, in_features: int, out_features: int):
         super().__init__()

--- a/opacus/tests/utils.py
+++ b/opacus/tests/utils.py
@@ -19,18 +19,6 @@ class BasicSupportedModule(nn.Module):
         return x
 
 
-class BasicBatchNormModel(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.fc = nn.Linear(4, 8)
-        self.bn = nn.BatchNorm2d(16)
-
-    def forward(self, x):
-        x = self.fc(x)
-        x = self.bn(x)
-        return x
-
-
 class CustomLinearModule(nn.Module):
     def __init__(self, in_features: int, out_features: int):
         super().__init__()

--- a/opacus/validators/batch_norm.py
+++ b/opacus/validators/batch_norm.py
@@ -72,7 +72,7 @@ def fix(module: BATCHNORM, **kwargs) -> Union[nn.GroupNorm, INSTANCENORM]:
     return (
         _batchnorm_to_instancenorm(module)
         if is_replace_bn_with_in
-        else _batchnorm_to_groupnorm(module, num_groups)
+        else _batchnorm_to_groupnorm(module, num_groups=num_groups)
     )
 
 

--- a/opacus/validators/batch_norm.py
+++ b/opacus/validators/batch_norm.py
@@ -77,7 +77,7 @@ def fix(module: BATCHNORM, **kwargs) -> Union[nn.GroupNorm, INSTANCENORM]:
 
 
 def _batchnorm_to_groupnorm(
-    module: BATCHNORM, num_groups: Optional[int] = None
+    module: BATCHNORM, *, num_groups: Optional[int] = None
 ) -> nn.GroupNorm:
     """
     Converts a BatchNorm ``module`` to GroupNorm module.


### PR DESCRIPTION
## Problem
As highlighted by #567, end user have little control over how exactly `ModelValidator.fix()` deals with BatchNorms.
For example, our approach to choosing number of groups is `gcd(32, module.num_features)`, which is fine for most cases, but can break a model occasionally (see #567 for a demonstration)

## Solution
Pass `num_groups` as kwarg, allowing clients to control the behaviour
