### PR TITLE
Fix the import order for D51126461

### DIFF
--- a/opacus/tests/batch_memory_manager_test.py
+++ b/opacus/tests/batch_memory_manager_test.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 import torch.nn as nn
-from hypothesis import given, settings, HealthCheck
+from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from opacus import PrivacyEngine
 from opacus.utils.batch_memory_manager import BatchMemoryManager

--- a/opacus/tests/privacy_engine_test.py
+++ b/opacus/tests/privacy_engine_test.py
@@ -26,7 +26,7 @@ import hypothesis.strategies as st
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from hypothesis import given, settings, HealthCheck
+from hypothesis import HealthCheck, given, settings
 from opacus import PrivacyEngine
 from opacus.layers.dp_multihead_attention import DPMultiheadAttention
 from opacus.optimizers.optimizer import _generate_noise


### PR DESCRIPTION
Summary: In D51126461, we did not import the library according to the alphabetical order, therefore triggering some linter test failure. We therefore made this diff to fix it.

Differential Revision: D51166750


