### PR TITLE
Remove requirement to be in training mode to capture activations

### DIFF
--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -273,7 +273,6 @@ class GradSampleModule(AbstractGradSampleModule):
     ):
         if (
             not requires_grad(module)
-            or not module.training
             or not torch.is_grad_enabled()
         ):
             return


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

In some contexts it is necessary to compute gradients during validations and/or testing. 

However, there is currently an explicit check that -- even if the gradients are manually enabled -- activations are captured solely during training.

This leads to the folllowing error:

![image](https://github.com/pytorch/opacus/assets/11019190/927068ef-bf2a-4be9-95a5-5755b5514d33)



## How Has This Been Tested (if it applies)

Manual testing on local project.


## Checklist 

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
