### PR TITLE
Added GitHub citation file.

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,43 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: >-
+  Opacus: User-Friendly Differential Privacy Library in
+  PyTorch
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Ashkan
+    family-names: Yousefpour
+  - given-names: Igor
+    family-names: Shilov
+  - given-names: Alexandre
+    family-names: Sablayrolles
+  - given-names: Davide
+    family-names: Testuggine
+  - given-names: Karthik
+    family-names: Prasad
+  - given-names: Mani
+    family-names: Malek
+  - given-names: John
+    family-names: Nguyen
+  - given-names: Sayan
+    family-names: Ghosh
+  - given-names: Akash
+    family-names: Bharadwaj
+  - given-names: Jessica
+    family-names: Zhao
+  - given-names: Graham
+    family-names: Cormode
+  - given-names: Ilya
+    family-names: Mironov
+identifiers:
+  - type: doi
+    value: 10.48550/arXiv.2109.12298
+repository-code: 'https://github.com/pytorch/opacus'
+url: 'https://opacus.ai/'
+abstract: Training PyTorch models with differential privacy.
+license: Apache-2.0


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
GitHub introduces the citation file format to make it easier to discover and work with software that can be cited. Following the already provided citation inside the README, I created the corresponding citation file.

Similar to https://github.com/pytorch/pytorch, a new `Cite this repository` button will now be displayed on the right-hand side of the webpage inside the `About` section (see attached screenshot).

There are two things I'd like to point out:

1. The citation type is now software instead of the original article. This can be changed using a `preferred-citation` key according to the [official GitHub documentation](https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#preferred-citation).
2. PyTorch has an organization attached to its citation. If this is applicable here too, then the file needs to be edited.

![image](https://github.com/pytorch/opacus/assets/5113257/3577bcda-5476-43dc-9d14-ed903170c7d9)

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
