### PR TITLE
Grant "write" permission to "github-actions[bot]"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    permissions:
+      # Grant write permission here so it can be pushed to gh-pages branch
+      contents: write
     defaults:
       run:
         working-directory: website


### PR DESCRIPTION
Summary: Grant "write" permission to "github-actions[bot]" to avoid permission issue in deploying github page (https://github.com/pytorch/opacus/actions/runs/7659084329).

Differential Revision: D53131111


