### PR TITLE
refactor: delete unused code line

### DIFF
--- a/examples/cifar10.py
+++ b/examples/cifar10.py
@@ -33,7 +33,6 @@ import torch.utils.data.distributed
 import torchvision.transforms as transforms
 from opacus import PrivacyEngine
 from opacus.distributed import DifferentiallyPrivateDistributedDataParallel as DPDDP
-from opacus.grad_sample.functorch import make_functional
 from torch.func import grad, grad_and_value, vmap
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torchvision.datasets import CIFAR10


### PR DESCRIPTION
## Types of changes
bugfix: when use example of cifar10.py,will generate this error: 
```
Traceback (most recent call last):
  File "cifar.py", line 36, in <module>
    from opacus.grad_sample.functorch import make_functional
ImportError: cannot import name 'make_functional' from 'opacus.grad_sample.functorch' (/root/miniconda3/lib/python3.8/site-packages/opacus/grad_sample/functorch.py)
```
## Motivation and Context / Related issue
## How Has This Been Tested (if it applies)
## Checklist
