### PR TITLE
Fixed Opacus's Runtime error with an empty batch (issue 612)

### DIFF
--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -396,7 +396,9 @@ class DPOptimizer(Optimizer):
 
         if len(self.grad_samples[0]) == 0:
             # Empty batch
-            per_sample_clip_factor = torch.zeros((0,))
+            per_sample_clip_factor = torch.zeros(
+                (0,), device=self.grad_samples[0].device
+            )
         else:
             per_param_norms = [
                 g.reshape(len(g), -1).norm(2, dim=-1) for g in self.grad_samples


### PR DESCRIPTION
Summary: In case of an empty batch, in the ```clip_and_accumulate``` function, the ```per_sample_clip_factor``` variable is set to a tensor of size 0. However, the device was not specified, which throws a runtime error. Added it.

Differential Revision: D53733081


