### PR TITLE
Fix the doctest due to numpy 2.0

### DIFF
--- a/opacus/accountants/analysis/rdp.py
+++ b/opacus/accountants/analysis/rdp.py
@@ -39,7 +39,7 @@ Example:
     ...     rdp += compute_rdp(q=q, noise_multiplier=sigma, steps=steps, orders=orders)
 
     >>> epsilon, opt_order = get_privacy_spent(orders=orders, rdp=rdp, delta=1e-5)
-    >>> epsilon, opt_order  # doctest: +NUMBER
+    >>> float(epsilon), int(opt_order)  # doctest: +NUMBER
     (0.336, 23)
 
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.15
+numpy>=1.15,<2.0
 torch>=2.0
 scipy>=1.2
 opt-einsum>=3.3.0


### PR DESCRIPTION
Summary:
Doctest fails due to numpy's upgrade into 2.0, which changes the way of printing.
https://github.com/astropy/astropy/issues/15095

Differential Revision: D58873298
