### PR TITLE
Explicit opt_einsum.contract import for linear.py

### DIFF
--- a/opacus/grad_sample/linear.py
+++ b/opacus/grad_sample/linear.py
@@ -18,7 +18,7 @@ from typing import Dict, List
 
 import torch
 import torch.nn as nn
-from opt_einsum import contract
+from opt_einsum.contract import contract
 
 from .utils import register_grad_sampler, register_norm_sampler
 


### PR DESCRIPTION
Summary:
`opt_einsum` package contains ambiguous imports. It has submodule `opt_einsum/contract.py` and at the same time has the following in `__init__.py`:
```
from .contract import contract
```

So normally `from opt_einsum import contract` should import the method not the module. Howeve, some build systems get confused.

This change removes ambiguity and shouldn't affect behaviour in any way

Differential Revision: D60134455
