### PR TITLE
Fix DistributedDP Optimizer for Fast Gradient Clipping

### DIFF
--- a/opacus/__init__.py
+++ b/opacus/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from . import utils
-from .grad_sample import GradSampleModule
+from .grad_sample import GradSampleModule, GradSampleModuleFastGradientClipping
 from .privacy_engine import PrivacyEngine
 from .version import __version__
 
@@ -22,6 +22,7 @@ from .version import __version__
 __all__ = [
     "PrivacyEngine",
     "GradSampleModule",
+    "GradSampleModuleFastGradientClipping",
     "utils",
     "__version__",
 ]

--- a/opacus/optimizers/ddpoptimizer_fast_gradient_clipping.py
+++ b/opacus/optimizers/ddpoptimizer_fast_gradient_clipping.py
@@ -76,6 +76,6 @@ class DistributedDPOptimizerFastGradientClipping(DPOptimizerFastGradientClipping
 
         if self.pre_step():
             self.reduce_gradients()
-            return self.original_optimizer.original_optimizer.step()
+            return self.original_optimizer.step()
         else:
             return None


### PR DESCRIPTION
Summary: The step function incorrectly called "original_optimizer.original_optimizer" instead of  "original_optimizer". Fixed it now.

Differential Revision: D60484128
