### PR TITLE
Towards making the interface of ghost clipping same as that of PyTorch

### DIFF
--- a/opacus/optimizers/__init__.py
+++ b/opacus/optimizers/__init__.py
@@ -39,12 +39,17 @@ __all__ = [
 
 
 def get_optimizer_class(clipping: str, distributed: bool, grad_sample_mode: str = None):
-    if clipping == "flat" and distributed is False:
+    if grad_sample_mode == "ghost":
+        if clipping == "flat" and distributed is False:
+            return DPOptimizerFastGradientClipping
+        elif clipping == "flat" and distributed is True:
+            return DistributedDPOptimizerFastGradientClipping
+        else:
+            raise ValueError(
+                f"Unsupported combination of parameters. Clipping: {clipping} and grad_sample_mode: {grad_sample_mode}"
+            )
+    elif clipping == "flat" and distributed is False:
         return DPOptimizer
-    elif clipping == "ghost" and distributed is False:
-        return DPOptimizerFastGradientClipping
-    elif clipping == "ghost" and distributed is True:
-        return DistributedDPOptimizerFastGradientClipping
     elif clipping == "flat" and distributed is True:
         return DistributedDPOptimizer
     elif clipping == "per_layer" and distributed is False:

--- a/opacus/tests/multigpu_gradcheck.py
+++ b/opacus/tests/multigpu_gradcheck.py
@@ -101,7 +101,7 @@ def run_ghost_clipping_test(
         loss_per_sample = loss_fn(outputs, y)
         torch.mean(loss_per_sample).backward(retain_graph=True)
         optimizer.zero_grad()
-        rescaled_loss_per_sample = ddp_model.get_coeff() * loss_per_sample
+        rescaled_loss_per_sample = ddp_model.get_clipping_coef() * loss_per_sample
         rescaled_loss = torch.sum(rescaled_loss_per_sample)
         ddp_model.disable_hooks()
         rescaled_loss.backward()


### PR DESCRIPTION
Summary: We define two classes DPLossFastGradientClipping and DPTensorFastGradientClipping in the utils fine, which allows us to repurpose loss.backward() to perform the two backward passes and loss scaling required to implement ghost clipping.

Differential Revision: D61162530
