### PR TITLE
Fix failed github action CIs

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -55,7 +55,7 @@ jobs:
           coverage run -m pytest --doctest-modules -p conftest --junitxml=unittest-py38-release-reports/junit.xml opacus
           coverage report -i -m
       - name: Store test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: unittest-py38-release-reports
           path: unittest-py38-release-reports
@@ -80,7 +80,7 @@ jobs:
           coverage run -m pytest --doctest-modules -p conftest --junitxml=unittest-py39-release-reports/junit.xml opacus
           coverage report -i -m
       - name: Store test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: unittest-py39-release-reports
           path: unittest-py39-release-reports
@@ -123,7 +123,7 @@ jobs:
           mkdir unittest-py39-nightly-reports
           python -m pytest --doctest-modules -p conftest --junitxml=unittest-py39-nightly-reports/junit.xml opacus
       - name: Store test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: unittest-py39-nightly-reports
           path: unittest-py39-nightly-reports
@@ -151,7 +151,7 @@ jobs:
           python -c "import torch; accuracy = torch.load('run_results_mnist_0.25_0.7_1.5_64_1.pt'); exit(0) if (accuracy[0]>0.78 and accuracy[0]<0.95) else exit(1)"
           coverage report -i -m
       - name: Store test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: mnist-cpu-reports
           path: runs/mnist/test-reports

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -72,7 +72,7 @@ jobs:
           python -c "import torch; accuracy = torch.load('run_results_mnist_0.25_0.7_1.5_64_1.pt'); exit(0) if (accuracy[0]>0.78 and accuracy[0]<0.95) else exit(1)"
 
       - name: Store MNIST test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: mnist-gpu-reports
           path: runs/mnist/test-reports
@@ -89,7 +89,7 @@ jobs:
           python -c "import torch; model = torch.load('model_best.pth.tar'); exit(0) if (model['best_acc1']>0.4 and model['best_acc1']<0.49) else exit(1)"
 
       - name: Store CIFAR10 test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: cifar10-gpu-reports
           path: runs/cifar10/test-reports
@@ -104,7 +104,7 @@ jobs:
       #     python -c "import torch; accuracy = torch.load('run_results_imdb_classification.pt'); exit(0) if (accuracy>0.54 and accuracy<0.66) else exit(1)"
 
       # - name: Store IMDb test results
-      #   uses: actions/upload-artifact@v2
+      #   uses: actions/upload-artifact@v4
       #   with:
       #     name: imdb-gpu-reports
       #     path: runs/imdb/test-reports
@@ -121,7 +121,7 @@ jobs:
       #     python -c "import torch; accuracy = torch.load('run_results_chr_lstm_classification.pt'); exit(0) if (accuracy>0.60 and accuracy<0.80) else exit(1)"
 
       # - name: Store test results
-      #   uses: actions/upload-artifact@v2
+      #   uses: actions/upload-artifact@v4
       #   with:
       #     name: charlstm-gpu-reports
       #     path: runs/charlstm/test-reports


### PR DESCRIPTION
Summary: actions/upload-artifact v2 has been deprecated. Made an update to v4 (https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/?fbclid=IwZXh0bgNhZW0CMTEAAR1iwvZrpiBOv2Q9J1q2Ge1ZuEH8XNOC2eb1Zlhr6Fg3Z_TshdH0qLDjCpQ_aem_LI9OLm9MWhuc9f0M8sZRjw).

Differential Revision: D62675356
