### PR TITLE
replace uses of np.ndarray with npt.NDArray (#680)

### DIFF
--- a/opacus/accountants/analysis/prv/prvs.py
+++ b/opacus/accountants/analysis/prv/prvs.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import Tuple
 
 import numpy as np
+import numpy.typing as npt
 from scipy import integrate
 from scipy.special import erfc
 
@@ -133,7 +134,7 @@ class TruncatedPrivacyRandomVariable:
 
 @dataclass
 class DiscretePRV:
-    pmf: np.ndarray
+    pmf: npt.NDArray
     domain: Domain
 
     def __len__(self) -> int:


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/captum/pull/1389

X-link: https://github.com/pytorch/botorch/pull/2586

X-link: https://github.com/pytorch/audio/pull/3846

X-link: https://github.com/pytorch/captum/pull/1387
X-link: https://github.com/pytorch/botorch/pull/2584
X-link: https://github.com/pytorch/audio/pull/3845

This replaces uses of `numpy.ndarray` in type annotations with `numpy.typing.NDArray`. In Numpy-1.24.0+ `numpy.ndarray` is annotated as generic type. Without template parameters it triggers static analysis errors: 
```counterexample
Generic type `ndarray` expects 2 type parameters.
```
`numpy.typing.NDArray` is an alias that provides default template parameters.

Differential Revision: D64619891


