### PR TITLE
Fix a doctest error with param_rename dictionary

### DIFF
--- a/opacus/layers/param_rename.py
+++ b/opacus/layers/param_rename.py
@@ -72,7 +72,8 @@ class RenameParamsMixin:
         self.parameters() proceeds recursively from the top, going into submodules after processing
         items at the current level, and will not return duplicates.
         """
-        for old_name, param in super().named_parameters():
+
+        for old_name, param in list(super().named_parameters()):
             if old_name in self.old_to_new:
                 new_name = self.old_to_new[old_name]
                 self.register_parameter(new_name, param)


### PR DESCRIPTION
Summary: One of the doc tests was failing (https://github.com/pytorch/opacus/actions/runs/11511705096/job/32045564214) becaue the list being iterated on was modified in the run. Fixed this bug.

Differential Revision: D65003266


