### PR TITLE
Extend timeout deadline for timed out health tests

### DIFF
--- a/opacus/tests/accountants_test.py
+++ b/opacus/tests/accountants_test.py
@@ -136,7 +136,7 @@ class AccountingTest(unittest.TestCase):
         ),
         delta=st.sampled_from([1e-4, 1e-5, 1e-6]),
     )
-    @settings(deadline=10000)
+    @settings(deadline=40000)
     def test_get_noise_multiplier_overshoot(self, epsilon, epochs, sample_rate, delta):
         noise_multiplier = get_noise_multiplier(
             target_epsilon=epsilon,

--- a/opacus/tests/batch_memory_manager_test.py
+++ b/opacus/tests/batch_memory_manager_test.py
@@ -59,7 +59,7 @@ class BatchMemoryManagerTest(unittest.TestCase):
         batch_size=st.sampled_from([8, 16, 64]),
         max_physical_batch_size=st.sampled_from([4, 8]),
     )
-    @settings(suppress_health_check=list(HealthCheck), deadline=10000)
+    @settings(suppress_health_check=list(HealthCheck), deadline=40000)
     def test_basic(
         self,
         num_workers: int,
@@ -119,7 +119,7 @@ class BatchMemoryManagerTest(unittest.TestCase):
         num_workers=st.integers(0, 4),
         pin_memory=st.booleans(),
     )
-    @settings(suppress_health_check=list(HealthCheck), deadline=10000)
+    @settings(suppress_health_check=list(HealthCheck), deadline=40000)
     def test_empty_batch(
         self,
         num_workers: int,

--- a/opacus/tests/per_sample_gradients_utils_test.py
+++ b/opacus/tests/per_sample_gradients_utils_test.py
@@ -71,7 +71,7 @@ class PerSampleGradientsUtilsTest(unittest.TestCase):
         groups=st.integers(1, 12),
         grad_sample_mode=st.sampled_from(get_grad_sample_modes(use_ew=True)),
     )
-    @settings(deadline=10000)
+    @settings(deadline=40000)
     def test_conv1d(
         self,
         N: int,
@@ -120,7 +120,7 @@ class PerSampleGradientsUtilsTest(unittest.TestCase):
         batch_first=st.booleans(),
         grad_sample_mode=st.sampled_from(get_grad_sample_modes(use_ew=True)),
     )
-    @settings(deadline=10000)
+    @settings(deadline=40000)
     def test_linear(
         self,
         N: int,


### PR DESCRIPTION
Summary:
Some health tests were timing out due to a preset timeout deadline of 10k ms. See e.g., here: https://www.internalfb.com/sandcastle/workflow/351280770940024747/artifact/actionlog.351280771033318826.stdout.1

{F1968816841}

Updated the timeout deadline to 40k ms, since most timed out tests fall within this duration.

Differential Revision: D66548226


