### PR TITLE
Remove **kwargs from prepare_optimizer

### DIFF
--- a/opacus/privacy_engine.py
+++ b/opacus/privacy_engine.py
@@ -136,7 +136,6 @@ class PrivacyEngine:
             loss_reduction=loss_reduction,
             generator=generator,
             secure_mode=self.secure_mode,
-            **kwargs,
         )
 
     def _prepare_data_loader(


### PR DESCRIPTION
Summary:
None of the optimizer classes accept **kwargs, so I am removing **kwargs from perpare_optimizer.

Otherwsie, the current code throws an error when creating a custom PrivacyEngine that takes in additional arguments.

Differential Revision: D67456352


