### PR TITLE
Add *kwargs to get_epsilon

### DIFF
--- a/opacus/accountants/gdp.py
+++ b/opacus/accountants/gdp.py
@@ -44,7 +44,7 @@ class GaussianAccountant(IAccountant):
         else:
             self.history = [(noise_multiplier, sample_rate, 1)]
 
-    def get_epsilon(self, delta: float, poisson: bool = True) -> float:
+    def get_epsilon(self, delta: float, poisson: bool = True, **kwargs) -> float:
         """
         Return privacy budget (epsilon) expended so far.
 

--- a/opacus/accountants/prv.py
+++ b/opacus/accountants/prv.py
@@ -81,7 +81,12 @@ class PRVAccountant(IAccountant):
             self.history.append((noise_multiplier, sample_rate, 1))
 
     def get_epsilon(
-        self, delta: float, *, eps_error: float = 0.01, delta_error: float = None
+        self,
+        delta: float,
+        *,
+        eps_error: float = 0.01,
+        delta_error: float = None,
+        **kwargs,
     ) -> float:
         """
         Return privacy budget (epsilon) expended so far.

--- a/opacus/accountants/rdp.py
+++ b/opacus/accountants/rdp.py
@@ -68,7 +68,10 @@ class RDPAccountant(IAccountant):
         return float(eps), float(best_alpha)
 
     def get_epsilon(
-        self, delta: float, alphas: Optional[List[Union[float, int]]] = None
+        self,
+        delta: float,
+        alphas: Optional[List[Union[float, int]]] = None,
+        **kwargs,
     ):
         """
         Return privacy budget (epsilon) expended so far.


### PR DESCRIPTION
Summary: Add **kwargs as argument to the get_epsilon() function in accountants. It allows for building custom PrivacyEngines that take in additional arguments.

Differential Revision: D67514874


