### PR TITLE
Enable multigpu_gradcheck unit test in CI

### DIFF
--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -9,29 +9,28 @@ on:
       - main
 
 jobs:
-  # Temporarily disable this test since there is no server including multiple GPUs.
-  # unittest_multi_gpu:
-  #   runs-on: 4-core-ubuntu-gpu-t4
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
+  unittest_multi_gpu:
+    runs-on: 4-core-ubuntu-gpu-t4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-  #     - name: Display Python version
-  #       run: python3 -c "import sys; print(sys.version)"
+      - name: Display Python version
+        run: python3 -c "import sys; print(sys.version)"
 
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: '3.x'
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
 
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         ./scripts/install_via_pip.sh -c
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          ./scripts/install_via_pip.sh -c
 
-  #     - name: Run multi-GPU unit tests
-  #       run: |
-  #         python3 -m unittest opacus.tests.multigpu_gradcheck.GradientComputationTest.test_gradient_correct
+      - name: Run multi-GPU unit tests
+        run: |
+          python3 -m unittest opacus.tests.multigpu_gradcheck.GradientComputationTest.test_gradient_correct
 
 
   integrationtest_py39_torch_release_cuda:


### PR DESCRIPTION
Summary: Not sure why the GPU unit tests have been disabled. Just use this diff to turn it on.

Differential Revision: D67957719


