### PR TITLE
Replace register_backward_hook with register_full_backward_hook

### DIFF
--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -207,7 +207,7 @@ class GradSampleModule(AbstractGradSampleModule):
             )
 
             self.autograd_grad_sample_hooks.append(
-                module.register_backward_hook(
+                module.register_full_backward_hook(
                     partial(
                         self.capture_backprops_hook,
                         loss_reduction=loss_reduction,


### PR DESCRIPTION
Summary: register_backward_hook is deprecated.

Differential Revision: D68562558


