### PR TITLE
Diasble distributed per-layer clipping with hooks grad sample mode

### DIFF
--- a/opacus/grad_sample/grad_sample_module.py
+++ b/opacus/grad_sample/grad_sample_module.py
@@ -207,7 +207,7 @@ class GradSampleModule(AbstractGradSampleModule):
             )
 
             self.autograd_grad_sample_hooks.append(
-                module.register_backward_hook(
+                module.register_full_backward_hook(
                     partial(
                         self.capture_backprops_hook,
                         loss_reduction=loss_reduction,

--- a/opacus/optimizers/__init__.py
+++ b/opacus/optimizers/__init__.py
@@ -56,7 +56,9 @@ def get_optimizer_class(clipping: str, distributed: bool, grad_sample_mode: str 
         return DPPerLayerOptimizer
     elif clipping == "per_layer" and distributed is True:
         if grad_sample_mode == "hooks":
-            return DistributedPerLayerOptimizer
+            raise ValueError(
+                "Distributed per-layer clipping with hooks is not supported. As an alternative, use 'ew' as grad sample mode."
+            )
         elif grad_sample_mode == "ew":
             return SimpleDistributedPerLayerOptimizer
         else:

--- a/opacus/optimizers/ddp_perlayeroptimizer.py
+++ b/opacus/optimizers/ddp_perlayeroptimizer.py
@@ -38,6 +38,11 @@ def _clip_and_accumulate_parameter(p: nn.Parameter, max_grad_norm: float):
 
 
 class SimpleDistributedPerLayerOptimizer(DPPerLayerOptimizer, DistributedDPOptimizer):
+    """
+    :class:`~opacus.optimizers.optimizer.DPOptimizer` that implements
+    per layer clipping strategy and is compatible with distributed data parallel. Used with "ew" grad sample mode.
+    """
+
     def __init__(
         self,
         optimizer: Optimizer,
@@ -67,7 +72,7 @@ class SimpleDistributedPerLayerOptimizer(DPPerLayerOptimizer, DistributedDPOptim
 class DistributedPerLayerOptimizer(DPOptimizer):
     """
     :class:`~opacus.optimizers.optimizer.DPOptimizer` that implements
-    per layer clipping strategy and is compatible with distributed data parallel
+    per layer clipping strategy and is compatible with distributed data parallel. Used with "hooks" grad sample mode.
     """
 
     def __init__(


### PR DESCRIPTION
Summary:
We disable support for distributed per-layer clipping with "hooks" grad sample mode, since it raises an error when using `register_full_backward_hook`. Distributed per-layer clipping with "ew" grad sample mode can still be used.

The issue arises because DistributedPerLayerOptimizer uses per-parameter hooks on top of the per-module hooks. During the backward pass, the per-parameter hooks fire before the per-module hooks. Per-sample gradients are computed when the per-module hooks fire, and an error occurs when the per-parameter hooks try to access the per-sample gradients before they are computed. Forcing the order in which hooks are called is not possible with PyTorch.

In the future, we may consider an approach that does not use per-parameter hooks. Given the limited use of per-layer clipping, we disable the faulty case of distributed data parallel with "hooks".

Differential Revision: D71706681


