### PR TITLE
Fix Fast Gradient Clipping bias gradient calculation for three dim data

### DIFF
--- a/opacus/grad_sample/linear.py
+++ b/opacus/grad_sample/linear.py
@@ -83,7 +83,6 @@ def compute_linear_norm_sample(
 
             ret[layer.weight] = torch.sqrt(ga)
         if layer.bias is not None and layer.bias.requires_grad:
-            ggT = torch.einsum("nik,njk->nij", backprops, backprops)
-            gg = torch.einsum("n...i,n...i->n", ggT, ggT).clamp(min=0)
-            ret[layer.bias] = torch.sqrt(gg)
+            ggT = torch.einsum("nik,njk->nij", backprops, backprops)  # batchwise g g^T
+            ret[layer.bias] = torch.sqrt(torch.einsum("n...i->n", ggT).clamp(min=0))
     return ret


### PR DESCRIPTION
Summary:
The bias grad calculation for three dim data was incorect. 

Let `G = g^Tg`, where `g`, of dimensions `Txd` be the per-sample activation gradient, where `T` is the number of tokens and `d` dimension.

The per-sample gradient norm  with respect to bias is 
`vec(G)^T vec(1)`, instead of the erroneous,`vec(G)^T vec(G)` before. This diff fixes it.

Reviewed By: HuanyuZhang

Differential Revision: D70823094


