### PR TITLE
Tensor Parallelism -- Review Version

### DIFF
--- a/examples/tensor_parallelism_llama.py
+++ b/examples/tensor_parallelism_llama.py
@@ -1,0 +1,197 @@
+import copy
+import logging
+import os
+import random
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from opacus.grad_sample import GradSampleModuleFastGradientClippingTP
+from opacus.optimizers import FSDPOptimizerFastGradientClipping
+from opacus.utils.fast_gradient_clipping_utils import DPLossFastGradientClipping
+from torch.distributed._tensor import Replicate
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    RowwiseParallel,
+    parallelize_module,
+)
+from transformers import LlamaConfig, LlamaForCausalLM
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+EMBEDDING_LENGTH = 32000
+OUTPUT_FEATURE_LENGTH = 4096
+SEQ_LENGTH = 1
+BATCH_SIZE = 1
+
+
+def get_input_and_output():
+    input = torch.randint(EMBEDDING_LENGTH, size=(BATCH_SIZE, SEQ_LENGTH))
+    # labels = torch.randint(100, size = (BATCH_SIZE, SEQ_LENGTH))
+    labels = torch.randn(size=(BATCH_SIZE, SEQ_LENGTH, EMBEDDING_LENGTH))
+    return input, labels
+
+
+def profile_mem(f, arg1=None, karg=None):
+    torch.cuda.reset_peak_memory_stats()
+    m1_max = torch.cuda.max_memory_allocated() / 2**20
+    m1 = torch.cuda.memory_allocated() / 2**20
+    assert m1 == m1_max
+
+    # if arg1 is not None and karg is not None:
+    #     ret = f(arg1, inputs = karg)
+    if arg1 is not None:
+        ret = f(arg1)
+    else:
+        ret = f()
+
+    m2_max_mem = torch.cuda.max_memory_allocated() / 2**20
+    m2 = torch.cuda.memory_allocated() / 2**20
+    print(f"Mem history: {m1} -> {m2_max_mem} -> {m2} MB\n")
+    print(f"Max Mem difference: {m2_max_mem-m1} MB\n")
+    return ret, m2_max_mem - m1
+
+
+# pyre-ignore
+def model_parallel(rank, world_size):
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = "12345"
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    if not dist.is_initialized():
+        dist.init_process_group("nccl", rank=rank, world_size=world_size)
+
+    print("current_local_rank is", rank)
+
+    torch.cuda.set_device(rank)
+
+    input, labels = get_input_and_output()
+
+    # Define Llama model
+    model_config = LlamaConfig()
+
+    torch.cuda.reset_peak_memory_stats()
+
+    llama_model = LlamaForCausalLM(model_config).to(device="cuda")
+
+    random.seed(42)
+
+    llama_model.init_weights()
+    llama_model.train()
+
+    torch.cuda.reset_peak_memory_stats()
+    m1 = torch.cuda.memory_allocated() / 2**20
+
+    # Define the tensor parallelization plan
+    tp_mesh = init_device_mesh("cuda", (world_size,))
+    for layer_id, transformer_block in enumerate(llama_model.model.layers):
+        layer_tp_plan = {
+            # by default ColwiseParallel input layouts is replicated
+            # and RowwiseParallel output layouts is replicated
+            "self_attn.q_proj": ColwiseParallel(),
+            "self_attn.k_proj": ColwiseParallel(),
+            "self_attn.v_proj": ColwiseParallel(),
+            "self_attn.o_proj": RowwiseParallel(),
+            "mlp.gate_proj": ColwiseParallel(),
+            "mlp.down_proj": RowwiseParallel(),
+            "mlp.up_proj": ColwiseParallel(),
+            # "input_layernorm": SequenceParallel(),
+            # "post_attention_layernorm": SequenceParallel(),
+        }
+        # Adjust attention module to use the local number of heads, or else there will be a dimension mismatch error
+        attn_layer = transformer_block.self_attn
+        attn_layer.num_heads = attn_layer.num_heads // tp_mesh.size()
+        attn_layer.num_key_value_heads = (
+            attn_layer.num_key_value_heads // tp_mesh.size()
+        )
+
+        # Freeze layernorm layers
+        for name, param in transformer_block.input_layernorm.named_parameters():
+            param.requires_grad = False
+        for (
+            name,
+            param,
+        ) in transformer_block.post_attention_layernorm.named_parameters():
+            param.requires_grad = False
+
+        # Custom parallelization plan for the model
+        parallelize_module(
+            module=transformer_block,
+            device_mesh=tp_mesh,
+            parallelize_plan=layer_tp_plan,
+        )
+
+    llama_model = parallelize_module(
+        llama_model,
+        tp_mesh,
+        {
+            "model.embed_tokens": RowwiseParallel(
+                input_layouts=Replicate(),
+            ),
+            # "model.norm": SequenceParallel(),
+            "lm_head": RowwiseParallel(input_layouts=Replicate()),
+        },
+    )
+
+    # Freeze the layernorm layers
+    # for name, param in llama_model.model.embed_tokens.named_parameters():
+    #     param.requires_grad = True
+    for name, param in llama_model.model.norm.named_parameters():
+        param.requires_grad = False
+
+    print("model architecture", llama_model)
+
+    m2_max_mem = torch.cuda.max_memory_allocated() / 2**20
+    m2 = torch.cuda.memory_allocated() / 2**20
+    print(f"Mem history: {m1} -> {m2_max_mem} -> {m2} MB\n")
+    print(f"Max Mem difference: {m2_max_mem-m1} MB\n")
+
+    DP_sharded_model = GradSampleModuleFastGradientClippingTP(
+        llama_model, loss_reduction="mean", batch_first=True
+    )
+
+    optimizer_gc = torch.optim.SGD(DP_sharded_model.parameters(), lr=1)
+    optimizer_gc = FSDPOptimizerFastGradientClipping(
+        optimizer_gc,
+        noise_multiplier=0.0,
+        max_grad_norm=0.1,
+        expected_batch_size=1,
+        loss_reduction="mean",
+    )
+
+    criterion_gc = torch.nn.CrossEntropyLoss(reduction="mean")
+    criterion_gc = DPLossFastGradientClipping(
+        DP_sharded_model, optimizer_gc, copy.deepcopy(criterion_gc)
+    )
+    optimizer_gc.zero_grad()
+
+    print("forward pass, memory usage")
+    output, temp = profile_mem(DP_sharded_model, input.to(device="cuda"))
+
+    loss = criterion_gc(output.logits.view(1, -1), labels.to(device="cuda").view(1, -1))
+
+    print("Backward pass, memory usage")
+    profile_mem(loss.backward)
+
+    print("Optimizer step, memory usage")
+    profile_mem(optimizer_gc.step)
+
+    print("zero gradient, memory usage")
+    profile_mem(optimizer_gc.zero_grad, True)
+
+
+def main():
+
+    n_gpus = torch.cuda.device_count()
+    print(n_gpus)
+    print(torch.version.cuda)
+    assert n_gpus >= 2, f"Requires at least 2 GPUs to run, but got {n_gpus}"
+    world_size = n_gpus
+    mp.spawn(model_parallel, args=(world_size,), nprocs=world_size, join=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tensor_parallelism_toy.py
+++ b/examples/tensor_parallelism_toy.py
@@ -1,0 +1,107 @@
+import copy
+import logging
+import os
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+import torch.nn.functional as F
+from opacus.grad_sample import GradSampleModuleFastGradientClippingTP
+from opacus.optimizers import FSDPOptimizerFastGradientClipping
+from opacus.utils.fast_gradient_clipping_utils import DPLossFastGradientClipping
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    RowwiseParallel,
+    parallelize_module,
+)
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class SampleModule(nn.Module):
+    def __init__(self):
+        super(SampleModule, self).__init__()
+        self.fc1 = nn.Linear(4, 32, bias=False)
+        self.fc2 = nn.Linear(32, 4, bias=False)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.fc2(x).flatten(start_dim=1)
+        x = F.softmax(x)
+        return x
+
+
+# pyre-ignore
+def model_parallel(rank, world_size, m):
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = "12345"
+    os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+
+    if not dist.is_initialized():
+        dist.init_process_group("nccl", rank=rank, world_size=world_size)
+
+    print("current_local_rank is", rank)
+
+    torch.cuda.set_device(rank)
+
+    input = torch.tensor([(-1.0, -1.0, -1.0, -1.0), (-2.0, -2.0, -2.0, -2.0)]).to(
+        device="cuda"
+    )
+    input = torch.unsqueeze(input, 0)
+    print("input shape is", input.shape)
+
+    tp_mesh = init_device_mesh("cuda", (2,))
+    sharded_model = parallelize_module(
+        m, tp_mesh, {"fc1": ColwiseParallel(), "fc2": RowwiseParallel()}
+    )
+
+    DP_sharded_model = GradSampleModuleFastGradientClippingTP(
+        sharded_model, loss_reduction="mean", batch_first=True
+    )
+
+    optimizer_gc = torch.optim.SGD(DP_sharded_model.parameters(), lr=1)
+    optimizer_gc = FSDPOptimizerFastGradientClipping(
+        optimizer_gc,
+        noise_multiplier=0.0,
+        max_grad_norm=0.1,
+        expected_batch_size=1,
+        loss_reduction="mean",
+    )
+
+    criterion = torch.nn.CrossEntropyLoss(reduction="mean")
+    criterion_gc = DPLossFastGradientClipping(
+        DP_sharded_model, optimizer_gc, copy.deepcopy(criterion)
+    )
+    optimizer_gc.zero_grad()
+
+    output = DP_sharded_model(input)
+    print("output shape is", output.shape)
+    label = torch.tensor([3]).to(device="cuda")
+
+    loss = criterion_gc(output, label)
+    loss.backward()
+    optimizer_gc.step()
+
+    for name, param in DP_sharded_model.named_parameters():
+        print(name, param.grad)
+
+
+def main():
+    n_gpus = torch.cuda.device_count()
+    assert n_gpus >= 2, f"Requires at least 2 GPUs to run, but got {n_gpus}"
+    world_size = n_gpus
+    m = SampleModule()
+    mp.spawn(
+        model_parallel,
+        args=(world_size, copy.deepcopy(m)),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/opacus/grad_sample/__init__.py
+++ b/opacus/grad_sample/__init__.py
@@ -25,6 +25,9 @@ from .grad_sample_module_fast_gradient_clipping import (  # noqa
 from .grad_sample_module_fast_gradient_clipping_fsdp import (  # noqa
     GradSampleModuleFastGradientClippingFSDP,
 )
+from .grad_sample_module_fast_gradient_clipping_tp import (  # noqa
+    GradSampleModuleFastGradientClippingTP,
+)
 from .group_norm import compute_group_norm_grad_sample  # noqa
 from .gsm_base import AbstractGradSampleModule
 from .gsm_exp_weights import GradSampleModuleExpandedWeights
@@ -45,6 +48,7 @@ __all__ = [
     "GradSampleModule",
     "GradSampleModuleFastGradientClipping",
     "GradSampleModuleFastGradientClippingFSDP",
+    "GradSampleModuleFastGradientClippingTP",
     "GradSampleModuleExpandedWeights",
     "GradSampleModuleNoOp",
     "AbstractGradSampleModule",

--- a/opacus/grad_sample/grad_sample_module_fast_gradient_clipping.py
+++ b/opacus/grad_sample/grad_sample_module_fast_gradient_clipping.py
@@ -206,6 +206,10 @@ class GradSampleModuleFastGradientClipping(GradSampleModule):
             loss_reduction=loss_reduction,
             batch_first=batch_first,
         )
+        activations = [
+            temp.to_local() if type(temp) is torch.distributed.tensor.DTensor else temp
+            for temp in activations
+        ]
 
         if self.use_ghost_clipping and type(module) in self.NORM_SAMPLERS:
             norm_sampler_fn = self.NORM_SAMPLERS[type(module)]

--- a/opacus/grad_sample/grad_sample_module_fast_gradient_clipping_tp.py
+++ b/opacus/grad_sample/grad_sample_module_fast_gradient_clipping_tp.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import warnings
+
+import torch
+from opacus.grad_sample.grad_sample_module_fast_gradient_clipping import (
+    GradSampleModuleFastGradientClipping,
+)
+
+
+logger = logging.getLogger(__name__)
+logger.disabled = False
+
+
+class GradSampleModuleFastGradientClippingTP(GradSampleModuleFastGradientClipping):
+    """
+    Hooks-based implementation of GradSampleModule with Fast Gradient and Ghost Clipping
+
+    Computes norms of gradients without gradient instantiation
+    """
+
+    def __init__(
+        self,
+        m: torch.nn.Module,
+        *,
+        batch_first=True,
+        loss_reduction="mean",
+        strict: bool = True,
+        force_functorch=False,
+        max_grad_norm=1,
+        use_ghost_clipping=True,
+    ):
+        super().__init__(
+            m,
+            batch_first=batch_first,
+            loss_reduction=loss_reduction,
+            strict=strict,
+            force_functorch=force_functorch,
+            max_grad_norm=max_grad_norm,
+            use_ghost_clipping=use_ghost_clipping,
+        )
+        self.set_pattern_param_sample_norm_sum()
+        warnings.warn(
+            "Opacus TP is currently in beta. Custom model output placements may cause unexpected behavior."
+        )
+
+    def set_pattern_param_sample_norm_sum(self):
+        """
+        When initializing the gradient sample module, the following function investigates the tensor parallelism state of different model parameters, and then decide whether or not to merge the per-sample gradient norm from local devices.
+
+        Specifically, under the following exceptions, we should not merge the per-sample norm from local devices, but maintain the one from device 0:
+        1. The parameter is not a DTensor.
+        2. The model is ``nn.embedding`` while under ``RowWiseParallel``.
+        3. The model weight is not sharded. For example, ``nn.linear.bias`` under ``RowWiseParallel``. This situation is currently unsupported since ``fsdpoptimizer`` requires all the parameters to be sharded.
+        """
+        for module in self.iterate_submodules(self._module):
+            for name, param in module.named_parameters():
+                if param.requires_grad:
+                    if type(param) is not torch.distributed.tensor.DTensor:
+                        param.merge_flag = False
+                    elif type(module) is torch.nn.Embedding and param.placements[
+                        0
+                    ].is_shard(0):
+                        param.merge_flag = False
+                    elif param.placements[0].is_replicate():
+                        param.merge_flag = False
+                        raise NotImplementedError(
+                            "We currently do not support replicated model parameters, due to the constraint of fsdpoptimizwer. This means that nn.Linear.bias must be disabled or configured to be sharded."
+                        )
+                    else:
+                        param.merge_flag = True
+
+    def get_norm_sample(self) -> torch.Tensor:
+        """Get per-example gradient norms."""
+        current_rank = torch.distributed.get_rank()
+
+        squared_norm_sample = (
+            torch.stack(
+                [
+                    (
+                        torch.zeros_like(param._norm_sample)
+                        if (not param.merge_flag and current_rank != 0)
+                        else param._norm_sample
+                    )
+                    for param in self.trainable_parameters
+                ],
+                dim=0,
+            )
+            .norm(2, dim=0)
+            .square()
+        )
+
+        torch.distributed.all_reduce(
+            squared_norm_sample, op=torch.distributed.ReduceOp.SUM
+        )
+        self.per_sample_gradient_norms = squared_norm_sample.sqrt()
+        return squared_norm_sample.sqrt()


### PR DESCRIPTION
Summary:
We add a class named `grad_sample_module_fast_gradient_clipping_tp` to support 1D tensor parallelism for Opacus. We demonstrate the effectiveness on a toy example (examples/tp_toy.py) and llama 2 model (examples/tp_llama.py).

The key contribution is to understand when merging per-sample norms from different local devices, the operation should be `reduce_all` or just keep the norm from device 0. Specifically, under the following exceptions:
1. The parameter is not a DTensor.
2. The model is nn.embedding and under RowWiseParallel.
3. The parameter is nn.linear.bias under RowWiseParallel.
We should not merge the per-sample norm from local devices, but maintain the one from device 0.

Currently, we do not support
1. Vanilla Opacus mode (non-GC).
2. Sequential Parallelism (usually applied to LayerNormalization).
3. Modify/customize the placements of module outputs, which might lead to wrong behavior of norm calculation.

Differential Revision: D79062242


