### PR TITLE
Fix IAccountant.mechanism accessed as a property

### DIFF
--- a/opacus/accountants/accountant.py
+++ b/opacus/accountants/accountant.py
@@ -97,7 +97,7 @@ class IAccountant(abc.ABC):
         if destination is None:
             destination = OrderedDict()
         destination["history"] = deepcopy(self.history)
-        destination["mechanism"] = self.__class__.mechanism
+        destination["mechanism"] = self.mechanism()
         return destination
 
     def load_state_dict(self, state_dict: T_state_dict):
@@ -126,9 +126,9 @@ class IAccountant(abc.ABC):
                 "state_dict does not have the key `mechanism`."
                 " Cannot be loaded into Privacy Accountant."
             )
-        if self.__class__.mechanism != state_dict["mechanism"]:
+        if self.mechanism() != state_dict["mechanism"]:
             raise ValueError(
                 f"state_dict of {state_dict['mechanism']} cannot be loaded into "
-                f" Privacy Accountant with mechanism {self.__class__.mechanism}"
+                f" Privacy Accountant with mechanism {self.mechanism()}"
             )
         self.history = state_dict["history"]


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

`Accountant.mechanism` is used as a class property in IAccountant state_dict methods, while it is an overloadable function in the code. It breaks state_dict functionality both ways.

## How Has This Been Tested (if it applies)

This modification has been used to implement a checkpointer for use in with Transformers library. It fails without it and works just fine with the fix.

Test was broken as well.

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
