### PR TITLE
Add accountant registry

### DIFF
--- a/opacus/accountants/__init__.py
+++ b/opacus/accountants/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Type
 
 from .accountant import IAccountant
 from .gdp import GaussianAccountant
@@ -24,13 +25,13 @@ __all__ = [
     "RDPAccountant",
 ]
 
+_ACCOUNTANTS = {"rdp": RDPAccountant, "gdp": GaussianAccountant, "prv": PRVAccountant}
+
+def register_accountant(mechanism: str, accountant: Type[IAccountant]):
+    _ACCOUNTANTS[mechanism] = accountant
 
 def create_accountant(mechanism: str) -> IAccountant:
-    if mechanism == "rdp":
-        return RDPAccountant()
-    elif mechanism == "gdp":
-        return GaussianAccountant()
-    elif mechanism == "prv":
-        return PRVAccountant()
+    if mechanism in _ACCOUNTANTS:
+        return _ACCOUNTANTS[mechanism]()
 
     raise ValueError(f"Unexpected accounting mechanism: {mechanism}")

--- a/opacus/accountants/__init__.py
+++ b/opacus/accountants/__init__.py
@@ -11,27 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Type
 
 from .accountant import IAccountant
 from .gdp import GaussianAccountant
 from .prv import PRVAccountant
 from .rdp import RDPAccountant
-
+from .registry import register_accountant, create_accountant
 
 __all__ = [
     "IAccountant",
     "GaussianAccountant",
     "RDPAccountant",
+    "PRVAccountant",
+    "register_accountant",
+    "create_accountant",
 ]
-
-_ACCOUNTANTS = {"rdp": RDPAccountant, "gdp": GaussianAccountant, "prv": PRVAccountant}
-
-def register_accountant(mechanism: str, accountant: Type[IAccountant]):
-    _ACCOUNTANTS[mechanism] = accountant
-
-def create_accountant(mechanism: str) -> IAccountant:
-    if mechanism in _ACCOUNTANTS:
-        return _ACCOUNTANTS[mechanism]()
-
-    raise ValueError(f"Unexpected accounting mechanism: {mechanism}")

--- a/opacus/accountants/__init__.py
+++ b/opacus/accountants/__init__.py
@@ -16,7 +16,8 @@ from .accountant import IAccountant
 from .gdp import GaussianAccountant
 from .prv import PRVAccountant
 from .rdp import RDPAccountant
-from .registry import register_accountant, create_accountant
+from .registry import create_accountant, register_accountant
+
 
 __all__ = [
     "IAccountant",

--- a/opacus/accountants/registry.py
+++ b/opacus/accountants/registry.py
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Type
+
+from .accountant import IAccountant
+from .gdp import GaussianAccountant
+from .prv import PRVAccountant
+from .rdp import RDPAccountant
+
+
+_ACCOUNTANTS: Dict[str, Type[IAccountant]] = {
+    "rdp": RDPAccountant,
+    "gdp": GaussianAccountant,
+    "prv": PRVAccountant,
+}
+
+
+def register_accountant(mechanism: str, accountant: Type[IAccountant]):
+    r"""
+    Register a new accountant class to be used with a specified mechanism name.
+
+    Args:
+        mechanism: Name of the mechanism to register the accountant for
+        accountant: Accountant class (subclass of IAccountant) to register
+
+    Example:
+        >>> register_accountant("my_accountant", MyAccountant)
+    """
+    _ACCOUNTANTS[mechanism] = accountant
+
+
+def create_accountant(mechanism: str) -> IAccountant:
+    r"""
+    Creates and returns an accountant instance for the specified privacy mechanism.
+
+    Args:
+        mechanism: Name of the privacy accounting mechanism to use.
+
+    Returns:
+        An instance of the appropriate accountant class (subclass of IAccountant)
+        for the specified mechanism.
+
+    Raises:
+        ValueError: If the specified mechanism is not registered.
+
+    Example:
+        >>> accountant = create_accountant("rdp")
+        >>> accountant.step(noise_multiplier=1.0, sample_rate=0.01)
+        >>> epsilon = accountant.get_epsilon(delta=1e-5)
+    """
+    if mechanism in _ACCOUNTANTS:
+        return _ACCOUNTANTS[mechanism]()
+
+    raise ValueError(f"Unexpected accounting mechanism: {mechanism}")

--- a/opacus/accountants/registry.py
+++ b/opacus/accountants/registry.py
@@ -27,7 +27,9 @@ _ACCOUNTANTS: Dict[str, Type[IAccountant]] = {
 }
 
 
-def register_accountant(mechanism: str, accountant: Type[IAccountant], force: bool = False):
+def register_accountant(
+    mechanism: str, accountant: Type[IAccountant], force: bool = False
+):
     r"""
     Register a new accountant class to be used with a specified mechanism name.
 

--- a/opacus/accountants/registry.py
+++ b/opacus/accountants/registry.py
@@ -27,17 +27,21 @@ _ACCOUNTANTS: Dict[str, Type[IAccountant]] = {
 }
 
 
-def register_accountant(mechanism: str, accountant: Type[IAccountant]):
+def register_accountant(mechanism: str, accountant: Type[IAccountant], force: bool = False):
     r"""
     Register a new accountant class to be used with a specified mechanism name.
 
     Args:
         mechanism: Name of the mechanism to register the accountant for
         accountant: Accountant class (subclass of IAccountant) to register
+        force: If True, overwrites existing accountant for the specified mechanism.
 
-    Example:
-        >>> register_accountant("my_accountant", MyAccountant)
+    Raises:
+        ValueError: If the mechanism is already registered.
     """
+    if mechanism in _ACCOUNTANTS and not force:
+        raise ValueError(f"Accountant for mechanism {mechanism} is already registered")
+
     _ACCOUNTANTS[mechanism] = accountant
 
 
@@ -54,11 +58,6 @@ def create_accountant(mechanism: str) -> IAccountant:
 
     Raises:
         ValueError: If the specified mechanism is not registered.
-
-    Example:
-        >>> accountant = create_accountant("rdp")
-        >>> accountant.step(noise_multiplier=1.0, sample_rate=0.01)
-        >>> epsilon = accountant.get_epsilon(delta=1e-5)
     """
     if mechanism in _ACCOUNTANTS:
         return _ACCOUNTANTS[mechanism]()

--- a/opacus/tests/accountants_test.py
+++ b/opacus/tests/accountants_test.py
@@ -22,11 +22,38 @@ from opacus.accountants import (
     PRVAccountant,
     RDPAccountant,
     create_accountant,
+    IAccountant,
+    register_accountant,
 )
 from opacus.accountants.utils import get_noise_multiplier
 
 
 class AccountingTest(unittest.TestCase):
+    def test_register_accountant(self) -> None:
+        class DummyAccountant(IAccountant):
+            def __init__(self):
+                pass
+
+            def __len__(self):
+                return 0
+
+            def step(self, **kwargs):
+                pass
+
+            def get_epsilon(self, **kwargs):
+                return 0.0
+
+            def mechanism(cls) -> str:
+                return "dummy"
+
+        register_accountant("dummy", DummyAccountant)
+        self.assertIsInstance(create_accountant("dummy"), DummyAccountant)
+        self.assertEqual(create_accountant("dummy").mechanism(), "dummy")
+
+    def test_get_accountant_not_registered(self) -> None:
+        with self.assertRaises(ValueError):
+            create_accountant("not_registered")
+
     def test_rdp_accountant(self) -> None:
         noise_multiplier = 1.5
         sample_rate = 0.04


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

Allows to register 3rd party accountants to be used in methods like `get_noised_multiplier` and generally introduces an extra extension point.

Closes #780 

## How Has This Been Tested (if it applies)

Used in our internal implementation with the accountant from [Felipe-Gomez/riskcal](https://github.com/Felipe-Gomez/riskcal).

## Checklist

- [ ] The documentation is up-to-date with the changes I made.
- [x] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [x] All tests passed, and additional code has been covered with new tests.
